### PR TITLE
perf(lcp): high-priority first image + preconnect

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,41 @@ add_action('wp_enqueue_scripts', function () {
   wp_enqueue_style('rt-child-flip', get_stylesheet_directory_uri() . '/assets/flipboxes.css', [], '1.1.0');
 });
 
+// LCP: prioritize first above-the-fold image on listings
+add_filter('post_thumbnail_html', function($html){
+  static $done = false;
+  if ( ! $done && (is_home() || is_archive()) ) {
+    $html = preg_replace('#\\sloading=("|\')lazy("|\')#i', '', $html);
+    $html = preg_replace('#<img\\s#', '<img fetchpriority="high" decoding="async" ', $html, 1);
+    $done = true;
+  }
+  return $html;
+}, 10, 5);
+
+add_action('wp_head', function(){
+  if ( !is_home() && !is_archive() ) return;
+  echo '<script>\n';
+  echo 'document.addEventListener("DOMContentLoaded", function () {\n';
+  echo '  var img = document.querySelector(".video-grid img, .tmw-grid img");\n';
+  echo '  if (img) {\n';
+  echo '    img.setAttribute("fetchpriority", "high");\n';
+  echo '    img.setAttribute("decoding", "async");\n';
+  echo '    img.removeAttribute("loading");\n';
+  echo '  }\n';
+  echo '});\n';
+  echo '</script>\n';
+});
+
+add_filter('wp_resource_hints', function($urls, $relation_type){
+  if ( 'preconnect' === $relation_type ) {
+    $urls[] = 'https://galleryn3.vcmdawe.com';
+  }
+  if ( 'dns-prefetch' === $relation_type ) {
+    $urls[] = '//galleryn3.vcmdawe.com';
+  }
+  return $urls;
+}, 10, 2);
+
 /**
  * Helper: total term count for a taxonomy (hide_empty aware)
  */


### PR DESCRIPTION
## Summary
- Ensure first above-the-fold image on home and archive pages bypasses lazy loading and receives `fetchpriority="high"` and `decoding="async"`
- Add DOM-ready fallback script to prioritize non-thumbnail grid images
- Preconnect and DNS-prefetch to external LCP image host

## Testing
- `php -l functions.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b6292900832494c6076584a43479