### PR TITLE
style(flipboxes): switch card aspect to 2:3 to avoid cropping 800×1200 images

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -39,10 +39,10 @@
   box-shadow:0 6px 22px rgba(0,0,0,.35);
   background:#0b0b0b;
   /* aspect ratio for consistent tiles */
-  aspect-ratio:4/5;
+  aspect-ratio:2/3;
 }
 /* fallback for browsers without aspect-ratio */
-.tmw-flip::before{ content:""; float:left; padding-bottom:125%; }
+.tmw-flip::before{ content:""; float:left; padding-bottom:150%; /* 3/2 = 1.5 */ }
 .tmw-flip::after{ content:""; display:block; clear:both; }
 
 .tmw-flip-inner{
@@ -55,6 +55,7 @@
   position:absolute; inset:0;
   background-size:cover;
   background-position:center;
+  background-repeat:no-repeat;
   backface-visibility:hidden;
 }
 .tmw-flip-back{ transform:rotateY(180deg); }


### PR DESCRIPTION
## Summary
- switch flipbox card aspect ratio to 2/3
- update `::before` fallback to `padding-bottom:150%`
- no other files changed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75bc6456c832488e19366ef5d065c