### PR TITLE
feat(models): show "View profile >>>" on back and link to biography

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -176,3 +176,15 @@
 }
 /* Ensure no arrows on the back side */
 .tmw-view::after{ content:""; }
+
+/* Back label: center, one line, show arrows, clickable feel */
+.tmw-view{
+  white-space: nowrap;
+  display: inline-block;
+  cursor: pointer;
+}
+.tmw-view::after{
+  content: " >>>";
+}
+/* Ensure accent red is our theme red */
+.tmw-grid{ --tmw-accent:#db001a; }

--- a/functions.php
+++ b/functions.php
@@ -166,14 +166,15 @@ add_shortcode('actors_flipboxes', function($atts){
 
     $link = get_term_link($term);
 
-    // === FRONT: actor name with small red arrow; BACK: red "Model profile" ===
+    // === FRONT: actor name with small red arrow; BACK: red "View profile" ===
     echo '<a class="tmw-flip" href="'.esc_url($link).'" aria-label="'.esc_attr($term->name).'">
             <div class="tmw-flip-inner">
               <div class="tmw-flip-front" style="background-image:url('.esc_url($front_url).');">
                 <span class="tmw-name">'.esc_html($term->name).'</span>
-              </div>
-              <div class="tmw-flip-back" style="background-image:url('.esc_url($back_url).');">
-                <span class="tmw-view">Model profile</span>
+              </div>';
+    // Back label; the entire card (including this text) links to the model's biography via $link.
+    echo '  <div class="tmw-flip-back" style="background-image:url('.esc_url($back_url).');">
+                <span class="tmw-view">View profile</span>
               </div>
             </div>
           </a>';


### PR DESCRIPTION
## Summary
- PHP: back label text set to "View profile"; $link = get_term_link($term) remains the single outer anchor → clicking text goes to the model’s biography page.
- CSS: .tmw-view forced to one line and >>> appended; pointer cursor for affordance; accent red stays #db001a.

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a764a887988324900d5ef55592de5c