### PR TITLE
feat(ui): add subtle pulse + arrow nudge to front flipbox label

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -237,3 +237,22 @@
   .tmw-flip-back .tmw-view,
   .tmw-flip-back .tmw-view::after{ animation: none !important; }
 }
+/* ===== Attention animations for FRONT label (actor name) ===== */
+.tmw-flip-front .tmw-name{
+  /* keep existing centering styles; add animation */
+  animation: tmw-pulse 1.6s ease-in-out infinite;
+  box-shadow: 0 0 0 rgba(219,0,26,0);
+  will-change: transform, box-shadow;
+}
+
+.tmw-flip-front .tmw-name::after{
+  /* we keep your existing '›››' or '>>>' content; just animate it */
+  animation: tmw-caret 1s ease-in-out infinite;
+  display: inline-block;
+}
+
+/* Respect users who prefer less motion */
+@media (prefers-reduced-motion: reduce){
+  .tmw-flip-front .tmw-name,
+  .tmw-flip-front .tmw-name::after{ animation: none !important; }
+}


### PR DESCRIPTION
## Summary
- animate front flipbox label with pulse and caret nudge
- respect reduced-motion preferences for front label animations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7797039388324b5f9844f0b7d719a