### PR TITLE
feat(models): switch bio hero to 16:9 landscape (1440×810)

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -198,6 +198,7 @@
 }
 .tmw-actor-bio{color:#ddd;margin:8px 0 6px}
 .tmw-actor-bio p{margin:0 0 10px}
+
 .tmw-actor-social{display:flex;flex-wrap:wrap;gap:10px;margin-top:8px}
 .tmw-social{
   display:inline-block;padding:6px 10px;border-radius:8px;
@@ -254,5 +255,14 @@
 /* Respect users who prefer less motion */
 @media (prefers-reduced-motion: reduce){
   .tmw-flip-front .tmw-name,
-  .tmw-flip-front .tmw-name::after{ animation: none !important; }
+.tmw-flip-front .tmw-name::after{ animation: none !important; }
+}
+
+/* Landscape hero on model biography */
+.tmw-actor-hero{ margin:0 0 12px; }
+.tmw-actor-hero-img{
+  width:100%; height:auto;
+  aspect-ratio:16/9; object-fit:cover;
+  border-radius:16px; box-shadow:0 6px 22px rgba(0,0,0,.35);
+  display:block;
 }

--- a/functions.php
+++ b/functions.php
@@ -90,6 +90,11 @@ add_filter('wp_resource_hints', function($urls, $relation_type){
   return $urls;
 }, 10, 2);
 
+// Landscape hero for model biography (retina-ready for ~720px display width)
+add_action('after_setup_theme', function () {
+  add_image_size('tmw-actor-hero-land', 1440, 810, true); // 16:9 hard crop
+});
+
 /**
  * Helper: total term count for a taxonomy (hide_empty aware)
  */

--- a/taxonomy-actors.php
+++ b/taxonomy-actors.php
@@ -9,16 +9,6 @@ $term     = get_queried_object();
 $term_id  = isset($term->term_id) ? (int)$term->term_id : 0;
 $acf_id   = 'actors_' . $term_id;
 
-// Photo (ACF front, then term thumbnail, else empty)
-$front    = function_exists('get_field') ? get_field('actor_card_front', $acf_id) : null;
-$front_url = (is_array($front) && !empty($front['url'])) ? $front['url'] : '';
-if (!$front_url) {
-  $thumb_id  = (int) get_term_meta($term_id, 'thumbnail_id', true);
-  if ($thumb_id) {
-    $front_url = wp_get_attachment_image_url($thumb_id, 'large');
-  }
-}
-
 // Description (term description supports HTML entered in admin)
 $bio_html = term_description($term_id, 'actors');
 
@@ -40,11 +30,34 @@ if (function_exists('get_field')) {
 <div class="tmw-layout">
   <main id="primary" class="site-main">
     <article class="tmw-actor">
-      <?php if ($front_url): ?>
-        <figure class="tmw-actor-photo">
-          <img src="<?php echo esc_url($front_url); ?>" alt="<?php echo esc_attr($term->name); ?>" loading="eager" fetchpriority="high" decoding="async" />
-        </figure>
-      <?php endif; ?>
+      <?php
+      // Hero image (ACF front preferred) → landscape size
+      $front     = function_exists('get_field') ? get_field('actor_card_front', $acf_id) : null;
+      $hero_html = '';
+      if (is_array($front) && !empty($front['ID'])) {
+        $hero_html = wp_get_attachment_image($front['ID'], 'tmw-actor-hero-land', false, [
+          'class' => 'tmw-actor-hero-img',
+          'alt'   => $term->name,
+          'loading' => 'eager',
+          'fetchpriority' => 'high',
+          'decoding' => 'async',
+        ]);
+      } else {
+        $thumb_id = (int) get_term_meta($term_id, 'thumbnail_id', true);
+        if ($thumb_id) {
+          $hero_html = wp_get_attachment_image($thumb_id, 'tmw-actor-hero-land', false, [
+            'class' => 'tmw-actor-hero-img',
+            'alt'   => $term->name,
+            'loading' => 'eager',
+            'fetchpriority' => 'high',
+            'decoding' => 'async',
+          ]);
+        }
+      }
+      if ($hero_html) {
+        echo '<figure class="tmw-actor-hero">'.$hero_html.'</figure>';
+      }
+      ?>
 
       <?php if ($bio_html): ?>
         <div class="tmw-actor-bio">


### PR DESCRIPTION
## Summary
- add tmw-actor-hero-land (1440×810, 16:9)
- render new hero above bio, preferring ACF image ID or term thumbnail; uses responsive wp_get_attachment_image
- add styles for landscape hero

## Testing
- `php -l functions.php`
- `php -l taxonomy-actors.php`


------
https://chatgpt.com/codex/tasks/task_e_68a786c06cf883248230f22fe47ff9c3