### PR TITLE
feat(models): add 1200×250 horizontal hero banner on biography (24:5)

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -266,3 +266,13 @@
   border-radius:16px; box-shadow:0 6px 22px rgba(0,0,0,.35);
   display:block;
 }
+
+/* ===== Model biography: horizontal hero banner (1200×250, 24:5) ===== */
+.tmw-actor-hero{ margin:0 0 14px; }
+.tmw-actor-hero-img{
+  width:100%; height:auto; display:block;
+  aspect-ratio: 24 / 5;          /* matches 1200×250 */
+  object-fit: cover;              /* hard-crop visually to banner */
+  border-radius: 16px;
+  box-shadow: 0 6px 22px rgba(0,0,0,.35);
+}

--- a/functions.php
+++ b/functions.php
@@ -95,6 +95,11 @@ add_action('after_setup_theme', function () {
   add_image_size('tmw-actor-hero-land', 1440, 810, true); // 16:9 hard crop
 });
 
+// Horizontal hero banner for model biography (24:5), retina-ready for ~600px–700px display widths
+add_action('after_setup_theme', function () {
+  add_image_size('tmw-actor-hero-banner', 1200, 250, true); // hard crop 1200×250
+});
+
 /**
  * Helper: total term count for a taxonomy (hide_empty aware)
  */

--- a/taxonomy-actors.php
+++ b/taxonomy-actors.php
@@ -9,6 +9,38 @@ $term     = get_queried_object();
 $term_id  = isset($term->term_id) ? (int)$term->term_id : 0;
 $acf_id   = 'actors_' . $term_id;
 
+// Build hero banner HTML (ACF "front" image preferred; otherwise taxonomy thumbnail)
+$front     = function_exists('get_field') ? get_field('actor_card_front', 'actors_' . $term_id) : null;
+$hero_html = '';
+
+if (is_array($front) && !empty($front['ID'])) {
+  $hero_html = wp_get_attachment_image($front['ID'], 'tmw-actor-hero-banner', false, [
+    'class'         => 'tmw-actor-hero-img',
+    'alt'           => $term->name,
+    'loading'       => 'eager',
+    'fetchpriority' => 'high',
+    'decoding'      => 'async',
+    'sizes'         => '(max-width: 1024px) 100vw, 720px',
+  ]);
+} else {
+  $thumb_id = (int) get_term_meta($term_id, 'thumbnail_id', true);
+  if ($thumb_id) {
+    $hero_html = wp_get_attachment_image($thumb_id, 'tmw-actor-hero-banner', false, [
+      'class'         => 'tmw-actor-hero-img',
+      'alt'           => $term->name,
+      'loading'       => 'eager',
+      'fetchpriority' => 'high',
+      'decoding'      => 'async',
+      'sizes'         => '(max-width: 1024px) 100vw, 720px',
+    ]);
+  }
+}
+
+// Output hero above the biography
+if ($hero_html) {
+  echo '<figure class="tmw-actor-hero">' . $hero_html . '</figure>';
+}
+
 // Description (term description supports HTML entered in admin)
 $bio_html = term_description($term_id, 'actors');
 
@@ -30,36 +62,7 @@ if (function_exists('get_field')) {
 <div class="tmw-layout">
   <main id="primary" class="site-main">
     <article class="tmw-actor">
-      <?php
-      // Hero image (ACF front preferred) → landscape size
-      $front     = function_exists('get_field') ? get_field('actor_card_front', $acf_id) : null;
-      $hero_html = '';
-      if (is_array($front) && !empty($front['ID'])) {
-        $hero_html = wp_get_attachment_image($front['ID'], 'tmw-actor-hero-land', false, [
-          'class' => 'tmw-actor-hero-img',
-          'alt'   => $term->name,
-          'loading' => 'eager',
-          'fetchpriority' => 'high',
-          'decoding' => 'async',
-        ]);
-      } else {
-        $thumb_id = (int) get_term_meta($term_id, 'thumbnail_id', true);
-        if ($thumb_id) {
-          $hero_html = wp_get_attachment_image($thumb_id, 'tmw-actor-hero-land', false, [
-            'class' => 'tmw-actor-hero-img',
-            'alt'   => $term->name,
-            'loading' => 'eager',
-            'fetchpriority' => 'high',
-            'decoding' => 'async',
-          ]);
-        }
-      }
-      if ($hero_html) {
-        echo '<figure class="tmw-actor-hero">'.$hero_html.'</figure>';
-      }
-      ?>
-
-      <?php if ($bio_html): ?>
+        <?php if ($bio_html): ?>
         <div class="tmw-actor-bio">
           <?php echo wp_kses_post($bio_html); ?>
         </div>


### PR DESCRIPTION
functions.php: add tmw-actor-hero-banner (1200×250) hard-cropped image size.

taxonomy-actors.php: render the new hero banner above the biography (ACF “front” preferred, fallback to term thumbnail); remove any portrait hero remnants.

assets/flipboxes.css: add banner styles with aspect-ratio: 24/5 and object-fit: cover.

No other files changed.

------
https://chatgpt.com/codex/tasks/task_e_68a78c88a4348324b035aed7f435e00b