### PR TITLE
chore(models): adjust bio hero banner to 1200×300 (4:1)

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -267,12 +267,12 @@
   display:block;
 }
 
-/* ===== Model biography: horizontal hero banner (1200×250, 24:5) ===== */
+/* Model biography: horizontal hero banner (1200×300, 4:1) */
 .tmw-actor-hero{ margin:0 0 14px; }
 .tmw-actor-hero-img{
   width:100%; height:auto; display:block;
-  aspect-ratio: 24 / 5;          /* matches 1200×250 */
-  object-fit: cover;              /* hard-crop visually to banner */
+  aspect-ratio: 4 / 1;      /* matches 1200×300 */
+  object-fit: cover;
   border-radius: 16px;
   box-shadow: 0 6px 22px rgba(0,0,0,.35);
 }
@@ -281,7 +281,7 @@
 .tmw-actor-hero{ margin:0 0 14px; }
 .tmw-actor-hero-img{
   width:100%; height:auto; display:block;
-  aspect-ratio: 24 / 5;        /* 1200×250 */
+  aspect-ratio: 4 / 1;        /* 1200×300 */
   object-fit: cover;
   border-radius: 16px;
   box-shadow: 0 6px 22px rgba(0,0,0,.35);

--- a/functions.php
+++ b/functions.php
@@ -95,11 +95,9 @@ add_action('after_setup_theme', function () {
   add_image_size('tmw-actor-hero-land', 1440, 810, true); // 16:9 hard crop
 });
 
-// Horizontal hero banner for model biography (24:5)
+// Horizontal hero banner for model biography (4:1)
 add_action('after_setup_theme', function () {
-  if (!has_image_size('tmw-actor-hero-banner')) {
-    add_image_size('tmw-actor-hero-banner', 1200, 250, true); // hard crop
-  }
+  add_image_size('tmw-actor-hero-banner', 1200, 300, true); // hard crop 1200×300
 });
 
 /**


### PR DESCRIPTION
## Summary
- register 1200×300 hero banner size for model biographies
- style hero banner with 4:1 aspect ratio

## Testing
- `php -l functions.php`
- `npm test` (fails: ENOENT package.json)
- `composer test` (fails: Command "test" is not defined.)

------
https://chatgpt.com/codex/tasks/task_e_68a82b2fbf288324990781ecdf1e385a