### PR TITLE
feat(models): per-model promo flipboxes under bio (editable links & texts)

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -297,3 +297,6 @@
   box-shadow:0 4px 14px rgba(219,0,26,.35);
 }
 .tmw-live-btn:hover{ filter:brightness(1.08); }
+
+/* Promo row under bio */
+.tmw-promos{ margin-top: 10px; }

--- a/functions.php
+++ b/functions.php
@@ -342,3 +342,110 @@ add_action('wp_footer', function(){ ?>
   })();
   </script>
 <?php }, 30);
+
+/* --- ACF: Promo flipboxes on Actors taxonomy --- */
+add_action('init', function () {
+  if (!function_exists('acf_add_local_field_group')) return;
+
+  // Avoid double-registering
+  if (!acf_get_local_field_group('group_tmw_actor_promos')) {
+    acf_add_local_field_group([
+      'key' => 'group_tmw_actor_promos',
+      'title' => 'Promo Flipboxes',
+      'fields' => [
+        [
+          'key' => 'field_tmw_promos',
+          'label' => 'Promo Flipboxes',
+          'name' => 'tmw_promos',
+          'type' => 'repeater',
+          'instructions' => 'Add external promo cards for this model. Each card can link to a different platform (OnlyFans, Fansly, Reddit, etc.).',
+          'collapsed' => 'field_tmw_label',
+          'min' => 0,
+          'max' => 12,
+          'layout' => 'row',
+          'button_label' => 'Add Promo Flipbox',
+          'sub_fields' => [
+            [
+              'key' => 'field_tmw_front',
+              'label' => 'Front Image',
+              'name' => 'front',
+              'type' => 'image',
+              'return_format' => 'array',
+              'preview_size' => 'medium',
+              'library' => 'all',
+            ],
+            [
+              'key' => 'field_tmw_back',
+              'label' => 'Back Image',
+              'name' => 'back',
+              'type' => 'image',
+              'return_format' => 'array',
+              'preview_size' => 'medium',
+              'library' => 'all',
+            ],
+            [
+              'key' => 'field_tmw_label',
+              'label' => 'Back-side Text',
+              'name' => 'label',
+              'type' => 'text',
+              'default_value' => 'View offer >>>',
+              'placeholder' => 'e.g. Follow on OnlyFans >>>',
+            ],
+            [
+              'key' => 'field_tmw_url',
+              'label' => 'External URL',
+              'name' => 'url',
+              'type' => 'url',
+              'placeholder' => 'https://...',
+            ],
+          ],
+        ],
+      ],
+      'location' => [[[
+        'param' => 'taxonomy',
+        'operator' => '==',
+        'value' => 'actors',
+      ]]],
+      'style' => 'default',
+      'position' => 'acf_after_term_description',
+      'active' => true,
+    ]);
+  }
+});
+
+/**
+ * Render promo flipboxes for a given actors term.
+ * @param int $term_id
+ * @param int $cols columns (2–4)
+ */
+function tmw_render_actor_promos(int $term_id, int $cols = 4) {
+  if (!function_exists('get_field')) return;
+
+  $items = get_field('tmw_promos', 'actors_' . $term_id);
+  if (empty($items) || !is_array($items)) return;
+
+  $cols = max(2, min(4, (int)$cols));
+
+  echo '<div class="tmw-grid tmw-cols-' . (int)$cols . ' tmw-promos">';
+  foreach ($items as $it) {
+    $front = is_array($it['front'] ?? null) ? ($it['front']['url'] ?? '') : '';
+    $back  = is_array($it['back']  ?? null) ? ($it['back']['url']  ?? '') : '';
+    $url   = esc_url($it['url']    ?? '');
+    $label = esc_html($it['label'] ?? 'Open >>>');
+
+    // Skip if no link or no imagery
+    if (empty($url) || (empty($front) && empty($back))) continue;
+    if (empty($back))  $back  = $front;
+    if (empty($front)) $front = $back;
+
+    echo '<a class="tmw-flip tmw-promo" href="'.$url.'" target="_blank" rel="nofollow sponsored noopener">';
+      echo '<div class="tmw-flip-inner">';
+        echo '<div class="tmw-flip-front" style="background-image:url('.esc_url($front).');"></div>';
+        echo '<div class="tmw-flip-back"  style="background-image:url('.esc_url($back).');">';
+          echo '<span class="tmw-view">'.$label.'</span>';
+        echo '</div>';
+      echo '</div>';
+    echo '</a>';
+  }
+  echo '</div>';
+}

--- a/taxonomy-actors.php
+++ b/taxonomy-actors.php
@@ -90,7 +90,12 @@ if (function_exists('get_field')) {
           echo '<div class="tmw-bio">'.wp_kses_post($desc).'</div>';
         } else {
           echo '<div class="tmw-bio tmw-bio-empty">No biography provided yet.</div>';
-        }
+      }
+      }
+
+      // Show promo flipboxes, default 4 columns (auto-responsive)
+      if (function_exists('tmw_render_actor_promos')) {
+        tmw_render_actor_promos($term->term_id, 4);
       }
 
       // Live link button (optional)


### PR DESCRIPTION
## Summary
- add ACF repeater for per-model promo flipboxes and rendering helper
- render promo flipboxes beneath model bio
- tweak CSS spacing for promo row

## Testing
- `php -l functions.php`
- `php -l taxonomy-actors.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8319dc7f48324aa95c75fff7791ea