### PR TITLE
Promo flipboxes: “View more >>>” on front; custom back text; open in new tab

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -426,7 +426,7 @@ function tmw_render_actor_promos($term_id){
     if (!$g) continue;
 
     $url   = isset($g['url'])   ? trim($g['url'])   : '';
-    $title = isset($g['title']) ? trim($g['title']) : '';
+    $title = isset($g['title']) ? trim($g['title']) : ''; // this is the BACK label (your custom text)
     $front = isset($g['front']['url']) ? $g['front']['url'] : '';
     $back  = isset($g['back']['url'])  ? $g['back']['url']  : $front;
 
@@ -447,11 +447,13 @@ function tmw_render_actor_promos($term_id){
       <?php foreach ($items as $it): ?>
         <a class="tmw-flip" href="<?php echo $it['url']; ?>" target="_blank" rel="sponsored nofollow noopener">
           <div class="tmw-flip-inner">
+            <!-- FRONT: fixed CTA -->
             <div class="tmw-flip-front" style="background-image:url('<?php echo $it['front']; ?>');">
-              <span class="tmw-name"><?php echo $it['title']; ?></span>
+              <span class="tmw-name">View more</span>
             </div>
+            <!-- BACK: your custom per-card text -->
             <div class="tmw-flip-back" style="background-image:url('<?php echo $it['back']; ?>');">
-              <span class="tmw-view">Open >>></span>
+              <span class="tmw-view"><?php echo $it['title']; ?></span>
             </div>
           </div>
         </a>


### PR DESCRIPTION
## Summary
- Replace promo renderer so each card has fixed "View more" front and customizable back label
- Ensure promo links open in a new tab with sponsorship attributes

## Testing
- `php -l functions.php`
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce572910832485df50e972822ee7