### PR TITLE
Labels: smaller font, single-line with ellipsis

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -69,21 +69,26 @@
 }
 
 /* ---------- OVERLAYS ---------- */
+/* Front & Back labels — smaller + single line */
 /* FRONT: actor name centered */
 .tmw-name{
   position:absolute; left:50%; bottom:12px;
   transform:translateX(-50%);
-  padding:6px 10px; border-radius:8px;
-  font-weight:800; font-size:1.05rem;
+  padding:5px 10px; border-radius:8px;
+  font-weight:800; font-size:.90rem;
   color:#fff; background:rgba(0,0,0,.55); line-height:1;
   text-decoration:none;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  max-width:88%;
 }
-/* Front label: add three red arrows */
+/* Front arrows smaller too (still in red) */
 .tmw-name::after{
   content:" >>>";
-  margin-left:10px;
+  margin-left:8px;
   font-weight:900;
-  font-size:1.25rem;
+  font-size:1rem;
   line-height:1;
   color:var(--tmw-accent);
 }
@@ -92,10 +97,20 @@
 .tmw-view{
   position:absolute; left:50%; bottom:12px;
   transform:translateX(-50%);
-  padding:6px 10px; border-radius:8px;
-  font-weight:800; font-size:1rem;
+  padding:5px 10px; border-radius:8px;
+  font-weight:800; font-size:.90rem;
   color:var(--tmw-accent); background:rgba(0,0,0,.55);
   text-decoration:none; line-height:1;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  max-width:88%;
+}
+
+/* Optional: slightly smaller on very small screens */
+@media (max-width:480px){
+  .tmw-name, .tmw-view{ font-size:.85rem; }
+  .tmw-name::after{ font-size:.95rem; }
 }
 
 /* ---------- BANNER BETWEEN ROWS ---------- */


### PR DESCRIPTION
## Summary
- Shrink front and back flipbox labels to 0.9rem with ellipsis and max-width constraints
- Reduce front arrow size and margin for a subtler look
- Add mobile media query to scale labels and arrows on very small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d25baaf883248be42c84118def4e