### PR TITLE
style(ux): double back action button on mobile only

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -267,3 +267,23 @@
 
 /* Promo row under bio */
 .tmw-promos{ margin-top: 10px; }
+
+/* ===== Mobile-only: 2× larger action button on flipbox back ===== */
+@media (max-width: 768px), (pointer: coarse){
+  .tmw-view{
+    font-size: 1.80rem;       /* ~2× typical .90rem base */
+    line-height: 1;
+    padding: 10px 16px;       /* ~2× padding for balance */
+    border-radius: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 92%;
+    cursor: pointer;
+  }
+  /* Scale arrows if present on the back label (harmless if none) */
+  .tmw-view::after{
+    font-size: 1.80rem;
+    line-height: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- increase flipbox back action button size only on mobile for better usability

## Testing
- Desktop: flip a card → back label size unchanged.
- Mobile: flip a card → back label is visibly ~2× larger, remains single-line with ellipsis if long.
- Promo cards still open external links only when tapping the back label; actor grid cards navigate to biography only when tapping the back label.
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ee23b8148324aa5ffcb2ba65082b