### PR TITLE
style(ux): double front flipbox label on mobile only

### DIFF
--- a/assets/flipboxes.css
+++ b/assets/flipboxes.css
@@ -287,3 +287,20 @@
     line-height: 1;
   }
 }
+/* ===== Mobile-only: 2× larger FRONT label on flipboxes ===== */
+@media (max-width: 768px), (pointer: coarse){
+  .tmw-name{
+    font-size: 1.80rem;       /* ~2× your typical .90rem base */
+    line-height: 1;
+    padding: 10px 16px;       /* ~2× padding for balance */
+    border-radius: 12px;
+    white-space: nowrap;      /* one line only */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 92%;           /* avoid spilling on narrow cards */
+  }
+  .tmw-name::after{
+    font-size: 1.80rem;       /* scale arrows too */
+    line-height: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Double front flipbox label text size on mobile, preserving single-line ellipsis and scaled arrow.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8efd7dfa88324b0eb6613de80b82d