### PR TITLE
Restore Models archive flipbox layout

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -10,42 +10,27 @@ get_header();
         'container_style' => 'margin:15px 0;',
     ]); ?>
 </div>
-<div class="tmw-layout model-archive-layout">
-    <main id="primary" class="site-main">
-        <header class="page-header">
-            <h1 class="page-title"><?php esc_html_e('Models', 'retrotube-child'); ?></h1>
-            <?php the_archive_description('<div class="archive-description">', '</div>'); ?>
-        </header>
 
-        <?php if (have_posts()) : ?>
-            <div class="model-archive-list">
-                <?php while (have_posts()) : the_post(); ?>
-                    <article id="post-<?php the_ID(); ?>" <?php post_class('model-archive-item'); ?>>
-                        <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+<main id="primary" class="site-main">
+    <div class="tmw-layout container model-archive-layout">
+        <section class="tmw-content">
+            <h1 class="tmw-title"><span class="tmw-star">★</span><?php esc_html_e('Models', 'retrotube-child'); ?></h1>
+            <?php
+            $archive_description = get_the_archive_description();
+            if ($archive_description) :
+                ?>
+                <div class="archive-description"><?php echo wp_kses_post($archive_description); ?></div>
+                <?php
+            endif;
 
-                        <?php if (has_post_thumbnail()) : ?>
-                            <a class="model-archive-thumb" href="<?php the_permalink(); ?>">
-                                <?php the_post_thumbnail('medium_large'); ?>
-                            </a>
-                        <?php endif; ?>
+            echo do_shortcode('[actors_flipboxes per_page="16" cols="4" show_pagination="true"]');
+            ?>
+        </section>
 
-                        <div class="entry-summary">
-                            <?php the_excerpt(); ?>
-                        </div>
-                    </article>
-                <?php endwhile; ?>
-            </div>
+        <aside class="tmw-sidebar">
+            <?php get_sidebar(); ?>
+        </aside>
+    </div>
+</main>
 
-            <?php the_posts_pagination([
-                'mid_size'  => 2,
-                'prev_text' => esc_html__('Previous', 'retrotube-child'),
-                'next_text' => esc_html__('Next', 'retrotube-child'),
-            ]); ?>
-        <?php else : ?>
-            <p class="no-models-found"><?php esc_html_e('No models found.', 'retrotube-child'); ?></p>
-        <?php endif; ?>
-    </main>
-
-    <?php get_sidebar(); ?>
-</div>
 <?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- replace the Models archive loop with the existing flipbox shortcode so the archive shows 16 flipboxes per page with the banner slot
- reuse the tmw-layout container/tmw-content structure and add a styled “Models” H1 along with the archive description ahead of the grid
- keep the sidebar inside the layout wrapper so the archive matches the flipbox templates

## Testing
- php -l archive-model.php

------
https://chatgpt.com/codex/tasks/task_e_68d3b83595dc8324a0a1b4b8686c3f5e