### PR TITLE
Revert removal of single-model_bio.php and breadcrumb override

### DIFF
--- a/breadcrumb.php
+++ b/breadcrumb.php
@@ -1,7 +1,0 @@
-<?php
-// Child theme override of RetroTube breadcrumb using Rank Math
-if (function_exists('rank_math_the_breadcrumbs')) {
-    echo '<div id="breadcrumbs">';
-    rank_math_the_breadcrumbs();
-    echo '</div>';
-}

--- a/functions.php
+++ b/functions.php
@@ -1955,41 +1955,6 @@ add_action('template_redirect', function () {
     }
 });
 
-/* ======================================================================
- * MODELS BREADCRUMB FIX (RANK MATH ONLY)
- * ====================================================================== */
-add_action('after_setup_theme', function () {
-    remove_action('retrotube_before_main_content', 'retrotube_breadcrumb', 20);
-
-    add_action('retrotube_before_main_content', function () {
-        if (!function_exists('rank_math_the_breadcrumbs')) {
-            return;
-        }
-
-        echo '<div id="breadcrumbs" class="rank-math-breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">';
-        rank_math_the_breadcrumbs();
-        echo '</div>';
-    }, 20);
-});
-
-// Enforce clean breadcrumb items for Models CPT
-add_filter('rank_math/frontend/breadcrumb/items', function($crumbs) {
-  if (is_post_type_archive('model')) {
-    return [
-      ['label' => 'Home', 'url' => home_url('/')],
-      ['label' => 'Models', 'url' => ''],
-    ];
-  }
-  if (is_singular('model')) {
-    return [
-      ['label' => 'Home', 'url' => home_url('/')],
-      ['label' => 'Models', 'url' => home_url('/models/')],
-      ['label' => get_the_title(), 'url' => ''],
-    ];
-  }
-  return $crumbs;
-});
-
 // Redirect legacy /model/ archive → /models/
 add_action('template_redirect', function () {
     if (is_admin()) {

--- a/single-model_bio.php
+++ b/single-model_bio.php
@@ -1,0 +1,44 @@
+<?php
+get_header();
+
+// Get ACF fields
+$bio = get_field('bio');
+$model_link = get_field('model_link');
+$banner = get_field('banner_image');
+$flipbox_shortcode = get_field('flipbox_shortcode');
+?>
+
+<div class="container model-bio-page">
+
+    <div class="model-header" style="text-align: center; margin-bottom: 30px;">
+        <h1><?php the_title(); ?></h1>
+
+        <?php if ($banner): ?>
+            <img src="<?php echo esc_url($banner); ?>" alt="<?php the_title(); ?>" style="max-width:100%; height:auto; margin-top: 15px;">
+        <?php endif; ?>
+    </div>
+
+    <div class="model-content">
+        <?php if ($bio): ?>
+            <div class="model-bio" style="margin-bottom: 30px;">
+                <?php echo wp_kses_post($bio); ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($flipbox_shortcode): ?>
+            <div class="model-flipbox" style="margin: 40px 0;">
+                <?php echo do_shortcode($flipbox_shortcode); ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($model_link): ?>
+            <div class="model-link" style="text-align: center; margin-top: 40px;">
+                <a href="<?php echo esc_url($model_link); ?>" class="btn" target="_blank" rel="nofollow">
+                    Visit <?php the_title(); ?> on LiveJasmin
+                </a>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- restore the previous single-model_bio.php template for model bios
- remove the Rank Math breadcrumb override so the parent breadcrumbs render again

## Testing
- php -l functions.php
- php -l single-model_bio.php

------
https://chatgpt.com/codex/tasks/task_e_68d40777a3748324994fc5ba152f7088