### PR TITLE
Ensure flipbox profile links resolve to model pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1281,6 +1281,7 @@ if (!function_exists('tmw_render_flipbox_card')) {
     $back_style  = (function_exists('tmw_bg_style') ? tmw_bg_style($back_url)  : 'background-image:url('.esc_url($back_url ).');') . ($ov['css_back']  ?? '');
 
     $link = tmw_get_model_link_for_term($term);
+    $link = apply_filters('tmw_model_flipbox_link', $link, $term);
     $name = $term->name;
 
     ob_start(); ?>
@@ -1440,6 +1441,7 @@ function tmw_models_flipboxes_cb($atts){
   $i = 0;
   foreach ($terms as $term){
     $link = tmw_get_model_link_for_term($term);
+    $link = apply_filters('tmw_model_flipbox_link', $link, $term);
 
     $front_url = '';
     $back_url  = '';

--- a/template-models-flipboxes.php
+++ b/template-models-flipboxes.php
@@ -10,7 +10,43 @@ get_header(); ?>
       <h1 class="section-title">Models</h1>
       <?php
       // Edit banner file at /assets/models-banner.html or pass banner_* via shortcode below.
+      $tmw_flipbox_link_filter = function ($link, $term) {
+        $home_url = trailingslashit(home_url('/'));
+        $current  = is_string($link) ? trailingslashit($link) : '';
+
+        if ($current && $current !== $home_url) {
+          return $link;
+        }
+
+        if (function_exists('tmw_get_model_post_for_term')) {
+          $post = tmw_get_model_post_for_term($term);
+          if ($post instanceof WP_Post) {
+            $post_link = get_permalink($post);
+            if ($post_link) {
+              return $post_link;
+            }
+          }
+        }
+
+        if (!$current || $current === $home_url) {
+          $term_obj = $term;
+          if (is_numeric($term)) {
+            $term_obj = get_term((int) $term, 'models');
+          }
+          if ($term_obj && !is_wp_error($term_obj)) {
+            $term_link = get_term_link($term_obj);
+            if (!is_wp_error($term_link) && $term_link) {
+              return $term_link;
+            }
+          }
+        }
+
+        return $link;
+      };
+
+      add_filter('tmw_model_flipbox_link', $tmw_flipbox_link_filter, 10, 2);
       echo do_shortcode('[actors_flipboxes per_page="16" cols="4" show_pagination="true"]');
+      remove_filter('tmw_model_flipbox_link', $tmw_flipbox_link_filter, 10);
       ?>
     </section>
     <aside class="tmw-sidebar">
@@ -18,4 +54,4 @@ get_header(); ?>
     </aside>
   </div>
 </main>
-<?php get_footer();
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- allow flipbox generators to run the `tmw_model_flipbox_link` filter before emitting their href values
- add a template-level filter that swaps homepage fallbacks for the linked model post or term permalink so the back-side "View profile" CTA reaches the model profile

## Testing
- php -l template-models-flipboxes.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d41632a9948324b1a5d957800c97b6