### PR TITLE
Fix Rank Math breadcrumbs for models archive

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1725,10 +1725,13 @@ add_filter('rank_math/frontend/breadcrumb/items', function ($crumbs) {
       continue;
     }
 
-    $label = strtolower($crumb['label']);
+    $label = strtolower(trim((string) $crumb['label']));
     if ($label === 'model' || $label === 'model bio') {
       $crumbs[$key]['label'] = 'Models';
+      $crumbs[$key]['title'] = 'Models';
       $crumbs[$key]['url']   = $models_url;
+
+      return $crumbs;
     }
   }
 


### PR DESCRIPTION
## Summary
- normalize breadcrumb labels before comparing
- force the model crumb to use the Models label/title/url and return immediately to avoid Rank Math fallback

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d42830fa848324a28cdd0886b59291