### PR TITLE
Hybrid setup for Models archive (SEO + editable content)

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -4,26 +4,19 @@
  */
 get_header();
 ?>
-<main id="primary" class="site-main">
-    <div class="tmw-layout container model-archive-layout">
-        <section class="tmw-content">
-            <h1 class="tmw-title"><span class="tmw-star">★</span><?php esc_html_e('Models', 'retrotube-child'); ?></h1>
-            <?php
-            $archive_description = get_the_archive_description();
-            if ($archive_description) :
-                ?>
-                <div class="archive-description"><?php echo wp_kses_post($archive_description); ?></div>
-                <?php
-            endif;
+<div class="container">
+  <?php get_template_part('breadcrumb'); ?>
 
-            echo do_shortcode('[actors_flipboxes per_page="16" cols="4" show_pagination="true"]');
-            ?>
-        </section>
+  <?php
+  $models_page = get_page_by_path('models');
+  if ($models_page instanceof WP_Post) {
+    echo '<div class="models-intro">';
+    echo apply_filters('the_content', $models_page->post_content);
+    echo '</div>';
+  }
+  ?>
 
-        <aside class="tmw-sidebar">
-            <?php get_sidebar(); ?>
-        </aside>
-    </div>
-</main>
-
-<?php get_footer(); ?>
+  <?php echo do_shortcode('[actors_flipboxes]'); ?>
+</div>
+<?php
+get_footer();

--- a/functions.php
+++ b/functions.php
@@ -85,6 +85,25 @@ add_action('template_redirect', function () {
   }
 });
 
+/**
+ * Ensure breadcrumb always shows Models
+ */
+add_filter('rank_math/frontend/breadcrumb/items', function ($crumbs) {
+  if (!is_array($crumbs)) return $crumbs;
+
+  foreach ($crumbs as $key => $crumb) {
+    if (!is_array($crumb) || !isset($crumb['label'])) continue;
+
+    $label = strtolower($crumb['label']);
+    if ($label === 'model' || $label === 'model bio') {
+      $crumbs[$key]['label'] = 'Models';
+      $crumbs[$key]['url']   = home_url('/models/');
+    }
+  }
+
+  return $crumbs;
+});
+
 /* ======================================================================
  * SAFE PLACEHOLDER (never 404s)
  * ====================================================================== */


### PR DESCRIPTION
## Summary
- ensure Rank Math breadcrumb entries for the model CPT always display "Models" linking to /models/
- load the hidden "Models" page content above the flipboxes on the models archive and output the breadcrumb partial

## Testing
- php -l functions.php
- php -l archive-model.php

------
https://chatgpt.com/codex/tasks/task_e_68d43548eae08324b1e1565c824d7b83