### PR TITLE
Fix model template layout wrappers

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -4,20 +4,24 @@
  */
 get_header();
 ?>
-<div class="container">
-  <?php get_template_part('breadcrumb'); ?>
+<div id="primary" class="content-area">
+  <main id="main" class="site-main">
+    <div class="container">
+      <?php get_template_part('breadcrumb'); ?>
 
-  <?php
-  // Pull content from the Page with slug "models"
-  $models_page = get_page_by_path('models');
-  if ($models_page instanceof WP_Post) {
-    echo '<div class="models-intro">';
-    echo apply_filters('the_content', $models_page->post_content);
-    echo '</div>';
-  }
-  ?>
+      <?php
+      // Pull content from the Page with slug "models"
+      $models_page = get_page_by_path('models');
+      if ($models_page instanceof WP_Post) {
+        echo '<div class="models-intro">';
+        echo apply_filters('the_content', $models_page->post_content);
+        echo '</div>';
+      }
+      ?>
 
-  <?php echo do_shortcode('[actors_flipboxes]'); ?>
+      <?php echo do_shortcode('[actors_flipboxes]'); ?>
+    </div>
+  </main>
 </div>
 <?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/single-model.php
+++ b/single-model.php
@@ -6,4 +6,15 @@
  * and breadcrumb logic.
  */
 
-require __DIR__ . '/single-model_bio.php';
+get_header();
+?>
+<div id="primary" class="content-area">
+  <main id="main" class="site-main">
+    <div class="container model-bio-page">
+      <?php get_template_part('breadcrumb'); ?>
+      <?php require __DIR__ . '/single-model_bio.php'; ?>
+    </div>
+  </main>
+</div>
+<?php get_sidebar(); ?>
+<?php get_footer(); ?>

--- a/single-model_bio.php
+++ b/single-model_bio.php
@@ -1,8 +1,4 @@
 <?php
-get_header();
-
-get_template_part('breadcrumb');
-
 // Get ACF fields
 $bio = get_field('bio');
 $model_link = get_field('model_link');
@@ -11,56 +7,51 @@ $flipbox_shortcode = get_field('flipbox_shortcode');
 $model_title = get_the_title();
 ?>
 
-<div class="container model-bio-page">
+<div class="model-header" style="text-align: center; margin-bottom: 30px;">
+    <h1><?php the_title(); ?></h1>
 
-    <div class="model-header" style="text-align: center; margin-bottom: 30px;">
-        <h1><?php the_title(); ?></h1>
+    <?php
+    if ($banner) {
+        $banner_url = '';
+        $banner_alt = '';
 
-        <?php
-        if ($banner) {
-            $banner_url = '';
-            $banner_alt = '';
-
-            if (is_array($banner)) {
-                $banner_url = isset($banner['url']) ? $banner['url'] : '';
-                $banner_alt = isset($banner['alt']) ? $banner['alt'] : '';
-            } elseif (is_string($banner)) {
-                $banner_url = $banner;
-            }
-
-            if (!empty($banner_url)) {
-                $alt_text = !empty($banner_alt) ? $banner_alt : $model_title;
-                ?>
-                <div class="model-hero">
-                    <img src="<?php echo esc_url($banner_url); ?>" alt="<?php echo esc_attr($alt_text); ?>" style="max-width:100%; height:auto; margin-top: 15px;">
-                </div>
-                <?php
-            }
+        if (is_array($banner)) {
+            $banner_url = isset($banner['url']) ? $banner['url'] : '';
+            $banner_alt = isset($banner['alt']) ? $banner['alt'] : '';
+        } elseif (is_string($banner)) {
+            $banner_url = $banner;
         }
-        ?>
-    </div>
 
-    <div class="model-content">
-        <?php if ($bio): ?>
-            <div class="model-bio" style="margin-bottom: 30px;">
-                <?php echo wp_kses_post($bio); ?>
+        if (!empty($banner_url)) {
+            $alt_text = !empty($banner_alt) ? $banner_alt : $model_title;
+            ?>
+            <div class="model-hero">
+                <img src="<?php echo esc_url($banner_url); ?>" alt="<?php echo esc_attr($alt_text); ?>" style="max-width:100%; height:auto; margin-top: 15px;">
             </div>
-        <?php endif; ?>
-
-        <?php if ($flipbox_shortcode): ?>
-            <div class="model-flipbox" style="margin: 40px 0;">
-                <?php echo do_shortcode($flipbox_shortcode); ?>
-            </div>
-        <?php endif; ?>
-
-        <?php if ($model_link): ?>
-            <div class="model-link" style="text-align: center; margin-top: 40px;">
-                <a href="<?php echo esc_url($model_link); ?>" class="btn" target="_blank" rel="nofollow">
-                    Visit <?php the_title(); ?> on LiveJasmin
-                </a>
-            </div>
-        <?php endif; ?>
-    </div>
+            <?php
+        }
+    }
+    ?>
 </div>
 
-<?php get_footer(); ?>
+<div class="model-content">
+    <?php if ($bio): ?>
+        <div class="model-bio" style="margin-bottom: 30px;">
+            <?php echo wp_kses_post($bio); ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($flipbox_shortcode): ?>
+        <div class="model-flipbox" style="margin: 40px 0;">
+            <?php echo do_shortcode($flipbox_shortcode); ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($model_link): ?>
+        <div class="model-link" style="text-align: center; margin-top: 40px;">
+            <a href="<?php echo esc_url($model_link); ?>" class="btn" target="_blank" rel="nofollow">
+                Visit <?php the_title(); ?> on LiveJasmin
+            </a>
+        </div>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
## Summary
- wrap the models archive loop with the primary/site-main structure so the sidebar can render
- update the single model template to include the bio partial inside the primary/site-main wrapper and share the breadcrumb container
- trim the model bio partial down to the hero/bio markup now that the parent template provides the header, container, sidebar, and footer

## Testing
- php -l archive-model.php
- php -l single-model.php
- php -l single-model_bio.php

------
https://chatgpt.com/codex/tasks/task_e_68d4e28c550c83248395cf6d4e6e4fe4