### PR TITLE
Fix model templates grid layout

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -4,9 +4,9 @@
  */
 get_header();
 ?>
-<div id="primary" class="content-area">
-  <main id="main" class="site-main">
-    <div class="container">
+<div id="primary" class="content-area container">
+  <div class="row">
+    <main id="main" class="site-main col-md-8">
       <?php get_template_part('breadcrumb'); ?>
 
       <?php
@@ -20,8 +20,10 @@ get_header();
       ?>
 
       <?php echo do_shortcode('[actors_flipboxes]'); ?>
-    </div>
-  </main>
+    </main>
+    <aside class="col-md-4">
+      <?php get_sidebar(); ?>
+    </aside>
+  </div>
 </div>
-<?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/single-model.php
+++ b/single-model.php
@@ -8,13 +8,15 @@
 
 get_header();
 ?>
-<div id="primary" class="content-area">
-  <main id="main" class="site-main">
-    <div class="container model-bio-page">
+<div id="primary" class="content-area container">
+  <div class="row">
+    <main id="main" class="site-main col-md-8 model-bio-page">
       <?php get_template_part('breadcrumb'); ?>
       <?php require __DIR__ . '/single-model_bio.php'; ?>
-    </div>
-  </main>
+    </main>
+    <aside class="col-md-4">
+      <?php get_sidebar(); ?>
+    </aside>
+  </div>
 </div>
-<?php get_sidebar(); ?>
 <?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- wrap the models archive template content and sidebar in the standard Bootstrap container/row grid
- apply the same Bootstrap grid structure to the single model template so the sidebar sits beside the main content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e5c4aca483248660b3011ca0c9a1