### PR TITLE
Add global featured models footer block

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2006,55 +2006,52 @@ if (!function_exists('tmw_featured_models_block')) {
       return;
     }
 
+    $template = locate_template('partials/featured-models-block.php', false, false);
+
+    if (!$template) {
+      return;
+    }
+
+    ob_start();
+    include $template;
+    $output = trim(ob_get_clean());
+
+    if ($output === '') {
+      return;
+    }
+
+    $rendered = true;
+
+    echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+  }
+}
+
+if (!function_exists('tmw_maybe_add_featured_models')) {
+  function tmw_maybe_add_featured_models() {
+    if (!function_exists('tmw_featured_models_block')) {
+      return;
+    }
+
     if (is_front_page()) {
       return;
     }
 
+    if (is_singular('model')) {
+      return;
+    }
+
     $video_post_types = ['video', 'videos', 'wpsc-video', 'wp-script-video', 'wpws_video'];
+
     foreach ($video_post_types as $video_post_type) {
       if (is_singular($video_post_type) || is_post_type_archive($video_post_type)) {
         return;
       }
     }
 
-    $model_ids = get_posts([
-      'post_type'      => 'model',
-      'post_status'    => 'publish',
-      'fields'         => 'ids',
-      'posts_per_page' => 4,
-      'orderby'        => 'rand',
-      'no_found_rows'  => true,
-      'suppress_filters' => false,
-    ]);
-
-    if (empty($model_ids)) {
-      return;
-    }
-
-    $ids = implode(',', array_map('intval', $model_ids));
-    if (!$ids) {
-      return;
-    }
-
-    $shortcode = sprintf('[actors_flipboxes ids="%s"]', esc_attr($ids));
-    $flipboxes  = do_shortcode($shortcode);
-
-    if (trim($flipboxes) === '') {
-      return;
-    }
-
-    $rendered = true;
-
-    echo '<div class="model-flipbox" style="margin:40px 0;">';
-    echo '<div class="tmwfm-wrap">';
-    echo '<h3 class="tmwfm-heading">FEATURED MODELS</h3>';
-    echo '<div class="tmwfm-grid">';
-    echo $flipboxes;
-    echo '</div>';
-    echo '</div>';
-    echo '</div>';
+    tmw_featured_models_block();
   }
 }
+add_action('get_footer', 'tmw_maybe_add_featured_models');
 
 /* ======================================================================
  * VIDEO FEATURED FLIPBOX META BOX

--- a/partials/featured-models-block.php
+++ b/partials/featured-models-block.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Reusable Featured Models block partial.
+ */
+
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+$model_ids = get_posts([
+  'post_type'         => 'model',
+  'post_status'       => 'publish',
+  'fields'            => 'ids',
+  'posts_per_page'    => 4,
+  'orderby'           => 'rand',
+  'no_found_rows'     => true,
+  'suppress_filters'  => false,
+]);
+
+if (empty($model_ids)) {
+  return;
+}
+
+$ids = implode(',', array_map('intval', $model_ids));
+
+if (!$ids) {
+  return;
+}
+
+$shortcode = sprintf('[actors_flipboxes ids="%s"]', esc_attr($ids));
+$flipboxes = do_shortcode($shortcode);
+
+if (trim($flipboxes) === '') {
+  return;
+}
+?>
+<div class="model-flipbox" style="margin:40px 0;">
+  <div class="tmwfm-wrap">
+    <h3 class="tmwfm-heading"><?php esc_html_e('Featured Models', 'retrotube-child'); ?></h3>
+    <div class="tmwfm-grid">
+      <?php echo $flipboxes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a reusable `partials/featured-models-block.php` partial that renders four random model flipboxes
- refactor `tmw_featured_models_block()` to load the partial and guard against duplicate output
- hook a new `tmw_maybe_add_featured_models()` function into `get_footer` so the block appears site-wide except on the front page, model, and video pages

## Testing
- php -l functions.php
- php -l partials/featured-models-block.php

------
https://chatgpt.com/codex/tasks/task_e_68d508ba4e9c83248b78508ab9ecc290