### PR TITLE
Unify featured models block across templates

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -18,8 +18,6 @@ get_header();
         echo '</div>';
       }
       ?>
-
-      <?php tmw_featured_models_block(); ?>
     </main>
     <aside class="col-md-4">
       <?php get_sidebar(); ?>

--- a/category.php
+++ b/category.php
@@ -2,8 +2,7 @@
 /**
  * Category archive template override for Retrotube Child theme.
  *
- * Delegates rendering to the parent template and injects a "Featured Models"
- * block just before the closing </main> element.
+ * Delegates rendering to the parent template.
  */
 
 $parent_template = '';
@@ -18,51 +17,29 @@ foreach (['category.php', 'archive.php', 'index.php'] as $candidate) {
 }
 
 if ($parent_template) {
-    ob_start();
     include $parent_template;
-    $parent_output = ob_get_clean();
-} else {
-    ob_start();
-    get_header();
-    ?>
-    <div id="content" class="site-content row">
-      <div id="primary" class="content-area with-sidebar-right category-archive">
-        <main id="main" class="site-main with-sidebar-right" role="main">
-          <?php if (have_posts()) : ?>
-            <?php while (have_posts()) : the_post(); ?>
-              <?php get_template_part('template-parts/content', get_post_type()); ?>
-            <?php endwhile; ?>
-
-            <?php the_posts_navigation(); ?>
-          <?php else : ?>
-            <?php get_template_part('template-parts/content', 'none'); ?>
-          <?php endif; ?>
-        </main>
-      </div>
-      <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
-        <?php get_sidebar(); ?>
-      </aside>
-    </div>
-    <?php
-    get_footer();
-    $parent_output = ob_get_clean();
+    return;
 }
 
-$featured_markup = '';
-if (function_exists('tmw_featured_models_block')) {
-    ob_start();
-    tmw_featured_models_block();
-    $featured_markup = ob_get_clean();
-}
+get_header();
+?>
+<div id="content" class="site-content row">
+  <div id="primary" class="content-area with-sidebar-right category-archive">
+    <main id="main" class="site-main with-sidebar-right" role="main">
+      <?php if (have_posts()) : ?>
+        <?php while (have_posts()) : the_post(); ?>
+          <?php get_template_part('template-parts/content', get_post_type()); ?>
+        <?php endwhile; ?>
 
-if ($featured_markup && trim($featured_markup) !== '') {
-    $updated_output = preg_replace('#</main>#i', $featured_markup . '</main>', $parent_output, 1, $replaced);
-
-    if (!$replaced) {
-        $updated_output = $parent_output . $featured_markup;
-    }
-
-    echo $updated_output;
-} else {
-    echo $parent_output;
-}
+        <?php the_posts_navigation(); ?>
+      <?php else : ?>
+        <?php get_template_part('template-parts/content', 'none'); ?>
+      <?php endif; ?>
+    </main>
+  </div>
+  <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
+    <?php get_sidebar(); ?>
+  </aside>
+</div>
+<?php
+get_footer();

--- a/functions.php
+++ b/functions.php
@@ -2036,16 +2036,8 @@ if (!function_exists('tmw_maybe_add_featured_models')) {
       return;
     }
 
-    if (is_singular('model')) {
+    if (is_post_type_archive('model')) {
       return;
-    }
-
-    $video_post_types = ['video', 'videos', 'wpsc-video', 'wp-script-video', 'wpws_video'];
-
-    foreach ($video_post_types as $video_post_type) {
-      if (is_singular($video_post_type) || is_post_type_archive($video_post_type)) {
-        return;
-      }
     }
 
     tmw_featured_models_block();

--- a/partials/featured-models-block.php
+++ b/partials/featured-models-block.php
@@ -36,7 +36,7 @@ if (trim($flipboxes) === '') {
 ?>
 <div class="model-flipbox" style="margin:40px 0;">
   <div class="tmwfm-wrap">
-    <h3 class="tmwfm-heading"><?php esc_html_e('Featured Models', 'retrotube-child'); ?></h3>
+    <h3 class="tmwfm-heading"><?php esc_html_e('FEATURED MODELS', 'retrotube-child'); ?></h3>
     <div class="tmwfm-grid">
       <?php echo $flipboxes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
     </div>

--- a/single-model.php
+++ b/single-model.php
@@ -17,7 +17,6 @@ get_header();
           <?php get_template_part('single-model_bio'); ?>
         <?php endwhile; ?>
       <?php endif; ?>
-      <?php tmw_featured_models_block(); ?>
     </main>
   </div>
   <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">

--- a/tag.php
+++ b/tag.php
@@ -2,8 +2,7 @@
 /**
  * Tag archive template override for Retrotube Child theme.
  *
- * Delegates rendering to the parent template and injects the global
- * Featured Models block just before the closing </main> element.
+ * Delegates rendering to the parent template.
  */
 
 $parent_template = '';
@@ -18,51 +17,29 @@ foreach (['tag.php', 'archive.php', 'index.php'] as $candidate) {
 }
 
 if ($parent_template) {
-    ob_start();
     include $parent_template;
-    $parent_output = ob_get_clean();
-} else {
-    ob_start();
-    get_header();
-    ?>
-    <div id="content" class="site-content row">
-      <div id="primary" class="content-area with-sidebar-right tag-archive">
-        <main id="main" class="site-main with-sidebar-right" role="main">
-          <?php if (have_posts()) : ?>
-            <?php while (have_posts()) : the_post(); ?>
-              <?php get_template_part('template-parts/content', get_post_type()); ?>
-            <?php endwhile; ?>
-
-            <?php the_posts_navigation(); ?>
-          <?php else : ?>
-            <?php get_template_part('template-parts/content', 'none'); ?>
-          <?php endif; ?>
-        </main>
-      </div>
-      <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
-        <?php get_sidebar(); ?>
-      </aside>
-    </div>
-    <?php
-    get_footer();
-    $parent_output = ob_get_clean();
+    return;
 }
 
-$featured_markup = '';
-if (function_exists('tmw_featured_models_block')) {
-    ob_start();
-    tmw_featured_models_block();
-    $featured_markup = ob_get_clean();
-}
+get_header();
+?>
+<div id="content" class="site-content row">
+  <div id="primary" class="content-area with-sidebar-right tag-archive">
+    <main id="main" class="site-main with-sidebar-right" role="main">
+      <?php if (have_posts()) : ?>
+        <?php while (have_posts()) : the_post(); ?>
+          <?php get_template_part('template-parts/content', get_post_type()); ?>
+        <?php endwhile; ?>
 
-if ($featured_markup && trim($featured_markup) !== '') {
-    $updated_output = preg_replace('#</main>#i', $featured_markup . '</main>', $parent_output, 1, $replaced);
-
-    if (!$replaced) {
-        $updated_output = $parent_output . $featured_markup;
-    }
-
-    echo $updated_output;
-} else {
-    echo $parent_output;
-}
+        <?php the_posts_navigation(); ?>
+      <?php else : ?>
+        <?php get_template_part('template-parts/content', 'none'); ?>
+      <?php endif; ?>
+    </main>
+  </div>
+  <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
+    <?php get_sidebar(); ?>
+  </aside>
+</div>
+<?php
+get_footer();

--- a/taxonomy-models.php
+++ b/taxonomy-models.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Single Model (models taxonomy)
- * Banner + Title Block + Bio (toggle) + Sidebar + Featured flipboxes
+ * Banner + Title Block + Bio (toggle) + Sidebar
  * Theme: Retrotube Child (Flipbox Edition)
  */
 get_header();
@@ -13,9 +13,6 @@ $acf_id  = 'models_' . $term_id;
 /* Biography (from ACF) */
 $bio        = function_exists('get_field') ? (get_field('bio', $acf_id) ?: '') : '';
 $read_lines = function_exists('get_field') ? ((int)(get_field('readmore_lines', $acf_id) ?: 20)) : 20;
-
-/* Featured shortcode (from ACF or fallback) */
-$featured_sc = function_exists('get_field') ? (get_field('featured_models_shortcode', $acf_id) ?: '[tmw_featured_models count="4"]') : '[tmw_featured_models count="4"]';
 
 /* Banner image */
 $banner_src = function_exists('tmw_resolve_model_banner_url') ? tmw_resolve_model_banner_url($term_id) : '';
@@ -41,7 +38,6 @@ $pos_y = max(0, min(100, 50 + $by));
       }
       .tmw-bio.js-clamp{display:-webkit-box; -webkit-box-orient:vertical; overflow:hidden; -webkit-line-clamp:<?php echo (int)$read_lines; ?>}
       .tmw-bio-toggle{margin-top:.5rem}
-      .tmw-featured-flipboxes{margin-top:24px}
     </style>
 
     <main class="tmw-model-main">
@@ -110,10 +106,6 @@ $pos_y = max(0, min(100, 50 + $by));
         <?php endif; ?>
       </div>
 
-      <section class="tmw-featured-flipboxes" aria-labelledby="featured-models-heading">
-        <h2 id="featured-models-heading" style="margin-bottom:10px;"><?php esc_html_e('Featured models', 'retrotube-child'); ?></h2>
-        <?php echo do_shortcode($featured_sc); ?>
-      </section>
     </main>
 
     <aside class="tmw-model-sidebar">

--- a/template-parts/content-video.php
+++ b/template-parts/content-video.php
@@ -176,13 +176,5 @@ if ( has_post_thumbnail() && wp_get_attachment_url( get_post_thumbnail_id() ) ) 
 		endif;
 	}
 
-	// 🔹 Featured Flipbox under comments
-	$flipbox_sc = get_post_meta( get_the_ID(), 'featured_flipbox_shortcode', true );
-	if ( empty( $flipbox_sc ) ) {
-		$flipbox_sc = '[tmw_featured_models]';
-	}
-	echo '<div class="video-featured-flipbox">';
-	echo do_shortcode( $flipbox_sc );
-	echo '</div>';
-	?>
+        ?>
 </article><!-- #post-## -->


### PR DESCRIPTION
## Summary
- add a reusable featured models partial that renders four random model flipboxes with consistent heading text
- hook the featured models block into the footer so it appears on every template except the front page and models archive
- remove legacy featured block injections from model, taxonomy, category, tag, and video templates to avoid duplicates

## Testing
- php -l functions.php
- php -l partials/featured-models-block.php
- php -l single-model.php
- php -l archive-model.php
- php -l category.php
- php -l tag.php
- php -l taxonomy-models.php
- php -l template-parts/content-video.php

------
https://chatgpt.com/codex/tasks/task_e_68d50c92bda08324b9bbcff26846d4c7