### PR TITLE
Align models archive layout with models grid

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -4,35 +4,18 @@
  */
 get_header();
 ?>
-<div class="tmw-title">
-  <span class="tmw-star">★</span>
-  <h1 class="tmw-title-text">Models</h1>
-</div>
-<div class="tmw-layout">
-  <main id="primary" class="site-main">
-    <?php get_template_part('breadcrumb'); ?>
-    <?php
-    $has_models = false;
-
-    if (function_exists('tmw_count_terms')) {
-      $has_models = tmw_count_terms('models', false) > 0;
-    } else {
-      $term_check = get_terms([
-        'taxonomy'   => 'models',
-        'hide_empty' => false,
-        'number'     => 1,
-        'fields'     => 'ids',
-      ]);
-      $has_models = !is_wp_error($term_check) && !empty($term_check);
-    }
-
-    if ($has_models) {
+<div id="content" class="site-content row">
+  <div id="primary" class="content-area with-sidebar-right models-archive">
+    <main id="main" class="site-main with-sidebar-right" role="main">
+      <?php get_template_part('breadcrumb'); ?>
+      <?php
       echo do_shortcode('[actors_flipboxes per_page="12" cols="3" show_pagination="true" page_var="pg"]');
-    } else {
-      echo '<p class="no-models-found">No models found.</p>';
-    }
-    ?>
-  </main>
-  <?php get_sidebar(); ?>
+      ?>
+    </main>
+  </div>
+  <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
+    <?php get_sidebar(); ?>
+  </aside>
 </div>
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/backups/archive-model.v1.0.php
+++ b/backups/archive-model.v1.0.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Archive template for the Models CPT.
+ */
+get_header();
+?>
+<div class="tmw-title">
+  <span class="tmw-star">★</span>
+  <h1 class="tmw-title-text">Models</h1>
+</div>
+<div class="tmw-layout">
+  <main id="primary" class="site-main">
+    <?php get_template_part('breadcrumb'); ?>
+    <?php
+    $has_models = false;
+
+    if (function_exists('tmw_count_terms')) {
+      $has_models = tmw_count_terms('models', false) > 0;
+    } else {
+      $term_check = get_terms([
+        'taxonomy'   => 'models',
+        'hide_empty' => false,
+        'number'     => 1,
+        'fields'     => 'ids',
+      ]);
+      $has_models = !is_wp_error($term_check) && !empty($term_check);
+    }
+
+    if ($has_models) {
+      echo do_shortcode('[actors_flipboxes per_page="12" cols="3" show_pagination="true" page_var="pg"]');
+    } else {
+      echo '<p class="no-models-found">No models found.</p>';
+    }
+    ?>
+  </main>
+  <?php get_sidebar(); ?>
+</div>
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- back up the previous models archive template for reference
- update the models archive to reuse the standard archive layout shell and the flipbox grid from the models grid page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01807c3ac83249170118625e4f375