### PR TITLE
Align models archive with grid template

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -1,15 +1,6 @@
 <?php
 /**
- * Archive template for the Models CPT.
+ * Archive template for Models CPT
+ * Safely reuses the Models Grid template.
  */
-get_header();
-?>
-<div class="tmw-layout">
-  <main id="primary" class="site-main">
-    <?php
-      echo do_shortcode('[actors_flipboxes per_page="12" cols="3" show_pagination="true" page_var="pg"]');
-    ?>
-  </main>
-  <?php get_sidebar(); ?>
-</div>
-<?php get_footer(); ?>
+locate_template('page-models-grid.php', true);

--- a/backups/archive-model.v1.0.php
+++ b/backups/archive-model.v1.0.php
@@ -4,18 +4,12 @@
  */
 get_header();
 ?>
-<div id="content" class="site-content row">
-  <div id="primary" class="content-area with-sidebar-right models-archive">
-    <main id="main" class="site-main with-sidebar-right" role="main">
-      <?php get_template_part('breadcrumb'); ?>
-      <?php
+<div class="tmw-layout">
+  <main id="primary" class="site-main">
+    <?php
       echo do_shortcode('[actors_flipboxes per_page="12" cols="3" show_pagination="true" page_var="pg"]');
-      ?>
-    </main>
-  </div>
-  <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
-    <?php get_sidebar(); ?>
-  </aside>
+    ?>
+  </main>
+  <?php get_sidebar(); ?>
 </div>
-<?php
-get_footer();
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- back up the previous Models archive template for safekeeping
- replace the archive template with a lightweight loader that reuses the grid layout so /models mirrors /models-2

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01fe3719c832491e937065ceee8ab