### PR TITLE
Add archive header for Models archive page

### DIFF
--- a/archive-model.php
+++ b/archive-model.php
@@ -1,6 +1,62 @@
 <?php
 /**
  * Archive template for Models CPT
- * Safely reuses the Models Flipboxes template.
+ * Safely reuses the Models Flipboxes template with archive header.
  */
-locate_template('template-models-flipboxes.php', true);
+
+get_header();
+?>
+<header class="entry-header">
+  <h1 class="widget-title"><i class="fa fa-star"></i> ★ Models</h1>
+</header>
+<main id="primary" class="site-main">
+  <div class="tmw-layout container">
+    <section class="tmw-content">
+      <h1 class="section-title">Models</h1>
+      <?php
+      // Edit banner file at /assets/models-banner.html or pass banner_* via shortcode below.
+      $tmw_flipbox_link_filter = function ($link, $term) {
+        $home_url = trailingslashit(home_url('/'));
+        $current  = is_string($link) ? trailingslashit($link) : '';
+
+        if ($current && $current !== $home_url) {
+          return $link;
+        }
+
+        if (function_exists('tmw_get_model_post_for_term')) {
+          $post = tmw_get_model_post_for_term($term);
+          if ($post instanceof WP_Post) {
+            $post_link = get_permalink($post);
+            if ($post_link) {
+              return $post_link;
+            }
+          }
+        }
+
+        if (!$current || $current === $home_url) {
+          $term_obj = $term;
+          if (is_numeric($term)) {
+            $term_obj = get_term((int) $term, 'models');
+          }
+          if ($term_obj && !is_wp_error($term_obj)) {
+            $term_link = get_term_link($term_obj);
+            if (!is_wp_error($term_link) && $term_link) {
+              return $term_link;
+            }
+          }
+        }
+
+        return $link;
+      };
+
+      add_filter('tmw_model_flipbox_link', $tmw_flipbox_link_filter, 10, 2);
+      echo do_shortcode('[actors_flipboxes per_page="16" cols="4" show_pagination="true"]');
+      remove_filter('tmw_model_flipbox_link', $tmw_flipbox_link_filter, 10);
+      ?>
+    </section>
+    <aside class="tmw-sidebar">
+      <?php get_sidebar(); ?>
+    </aside>
+  </div>
+</main>
+<?php get_footer(); ?>

--- a/backups/archive-model.v1.3.php
+++ b/backups/archive-model.v1.3.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Archive template for Models CPT
+ * Safely reuses the Models Flipboxes template.
+ */
+locate_template('template-models-flipboxes.php', true);


### PR DESCRIPTION
## Summary
- add an entry header to the models archive so the page matches other archive headers
- back up the previous archive template for easy restoration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0d3aa76b48324807426b1939b4668