### PR TITLE
Align Videos page template with homepage feed

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -4,34 +4,23 @@
  */
 get_header(); ?>
 
-<div id="primary" class="content-area">
-    <main id="main" class="site-main">
+<div id="primary" class="content-area with-sidebar-right">
+    <main id="main" class="site-main with-sidebar-right" role="main">
 
         <header class="entry-header">
             <h1 class="entry-title"><i class="fa fa-video-camera"></i> Videos</h1>
         </header>
 
         <?php
-        $paged = ( get_query_var('paged') ) ? get_query_var('paged') : 1;
-        $args = array(
-            'post_type'      => 'video',
-            'posts_per_page' => get_option('posts_per_page'),
-            'paged'          => $paged,
-        );
-        $videos = new WP_Query($args);
-
-        if ($videos->have_posts()) :
-            while ($videos->have_posts()) : $videos->the_post();
-                get_template_part('template-parts/content', 'video');
+        if ( have_posts() ) :
+            while ( have_posts() ) : the_post();
+                get_template_part( 'template-parts/content', get_post_format() );
             endwhile;
 
             the_posts_pagination();
-
         else :
-            echo '<p>No videos found.</p>';
+            get_template_part( 'template-parts/content', 'none' );
         endif;
-
-        wp_reset_postdata();
         ?>
 
     </main><!-- #main -->


### PR DESCRIPTION
## Summary
- replace the Videos page template with the standard loop used on the homepage
- ensure the layout keeps the sidebar and default pagination/empty-state partials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e14434fc832484293eadc47c2962