### PR TITLE
Load video widget on videos page

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -13,6 +13,9 @@ get_header(); ?>
 
         <?php
         // Use RetroTube's own homepage blocks
+        if ( is_page( 'videos' ) ) {
+            require_once locate_template( 'inc/widgets/widget-videos-block.php', true, true );
+        }
         if ( function_exists( 'widget_videos_block' ) ) {
             // Videos being watched
             widget_videos_block( array(


### PR DESCRIPTION
## Summary
- ensure the Videos page loads the widget template used on the homepage before invoking `widget_videos_block`
- keep the sidebar and footer structure untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f48dfc308324a0052bff9e1fca19