### PR TITLE
Use widget API for videos page blocks

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -12,34 +12,60 @@ get_header(); ?>
         </header>
 
         <?php
-        // Use RetroTube's own homepage blocks
-        if ( is_page( 'videos' ) ) {
-            require_once locate_template( 'inc/widgets/widget-videos-block.php', true, true );
+        global $wp_widget_factory;
+
+        $videos_widget_class = '';
+        $registered_widgets  = array();
+
+        if ( is_object( $wp_widget_factory ) && isset( $wp_widget_factory->widgets ) ) {
+            $registered_widgets = $wp_widget_factory->widgets;
         }
-        if ( function_exists( 'widget_videos_block' ) ) {
-            // Videos being watched
-            widget_videos_block( array(
+
+        if ( isset( $registered_widgets['RetroTube_Videos_Block_Widget'] ) ) {
+            $videos_widget_class = 'RetroTube_Videos_Block_Widget';
+        } elseif ( isset( $registered_widgets['Retrotube_Videos_Block_Widget'] ) ) {
+            $videos_widget_class = 'Retrotube_Videos_Block_Widget';
+        } elseif ( isset( $registered_widgets['Video_Block_Widget'] ) ) {
+            $videos_widget_class = 'Video_Block_Widget';
+        }
+
+        $videos_widget_args = array(
+            array(
                 'title' => __( 'Videos being watched', 'retrotube' ),
                 'orderby' => 'rand',
                 'posts_per_page' => 12,
                 'columns' => 4,
-            ) );
-
-            // Latest videos
-            widget_videos_block( array(
+            ),
+            array(
                 'title' => __( 'Latest videos', 'retrotube' ),
                 'orderby' => 'date',
                 'posts_per_page' => 12,
                 'columns' => 4,
-            ) );
-
-            // Longest videos
-            widget_videos_block( array(
+            ),
+            array(
                 'title' => __( 'Longest videos', 'retrotube' ),
                 'orderby' => 'duration',
                 'posts_per_page' => 12,
                 'columns' => 4,
-            ) );
+            ),
+        );
+
+        $videos_widget_display_args = array(
+            'before_widget' => '<div class="widget videos-block">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h2 class="widget-title">',
+            'after_title'   => '</h2>',
+        );
+
+        foreach ( $videos_widget_args as $widget_args ) {
+            if ( $videos_widget_class ) {
+                the_widget( $videos_widget_class, $widget_args, $videos_widget_display_args );
+                continue;
+            }
+
+            if ( function_exists( 'widget_videos_block' ) ) {
+                widget_videos_block( $widget_args );
+            }
         }
         ?>
 


### PR DESCRIPTION
## Summary
- replace the manual videos page widget rendering with WordPress's `the_widget()` helper
- detect the registered RetroTube videos widget class while keeping a fallback to the legacy function

## Testing
- not run (theme change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0f5a992e08324b3256da9486df7df