### PR TITLE
Fix videos page filters and widget link rewrites

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2548,7 +2548,15 @@ add_filter( 'widget_display_callback', function( $instance, $widget, $args ) {
     ob_start();
     $widget->widget( $args, $instance );
     $output = ob_get_clean();
-    echo str_replace( '/?filter=', '/videos/?filter=', $output );
+
+    $patterns = array(
+      '#https?://'.preg_quote( wp_parse_url( home_url(), PHP_URL_HOST ), '#' ).'/\?filter=#i',
+      '#/\?filter=#',
+    );
+
+    $output = preg_replace( $patterns, home_url( '/videos/?filter=' ), $output );
+
+    echo $output;
     return false;
   }
 

--- a/page-videos.php
+++ b/page-videos.php
@@ -30,14 +30,14 @@ get_header(); ?>
                     break;
 
                 case 'longest':
-                    $query_args['meta_key'] = '_duration';
+                    $query_args['meta_key'] = 'duration';
                     $query_args['orderby']  = 'meta_value_num';
                     $query_args['order']    = 'DESC';
                     $query_args['meta_type'] = 'NUMERIC';
                     break;
 
                 case 'popular':
-                    $query_args['meta_key'] = '_views';
+                    $query_args['meta_key'] = 'post_views_count';
                     $query_args['orderby']  = 'meta_value_num';
                     $query_args['order']    = 'DESC';
                     $query_args['meta_type'] = 'NUMERIC';
@@ -66,11 +66,12 @@ get_header(); ?>
                     $filter_query->the_post();
                     get_template_part( 'template-parts/loop', 'video' );
                 endwhile;
-                wp_reset_postdata();
                 ?>
             <?php else : ?>
                 <p><?php esc_html_e( 'No videos found for this filter.', 'retrotube-child' ); ?></p>
             <?php endif; ?>
+
+            <?php wp_reset_postdata(); ?>
 
         <?php elseif ( is_page( 'videos' ) ) : ?>
 


### PR DESCRIPTION
## Summary
- add filter-aware secondary query on the Videos page to render filtered video lists without affecting the main query
- adjust longest/popular ordering to use duration and post_views_count meta values and reset postdata after loops
- rewrite widget filter links (absolute and relative) so they always target /videos/

## Testing
- php -l page-videos.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e112962a188324945e76b85dbb438c