### PR TITLE
Fix videos filter rewriting and query handling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2549,12 +2549,10 @@ add_filter( 'widget_display_callback', function( $instance, $widget, $args ) {
     $widget->widget( $args, $instance );
     $output = ob_get_clean();
 
-    $patterns = array(
-      '#https?://'.preg_quote( wp_parse_url( home_url(), PHP_URL_HOST ), '#' ).'/\?filter=#i',
-      '#/\?filter=#',
-    );
-
-    $output = preg_replace( $patterns, home_url( '/videos/?filter=' ), $output );
+    $host = preg_quote( wp_parse_url( home_url(), PHP_URL_HOST ), '#' );
+    // Only rewrite links that point directly to ?filter= without the /videos/ prefix.
+    $pattern = '#(href=["\'])(?:https?://'.$host.')?/\?filter=([^"\']+)#i';
+    $output = preg_replace( $pattern, '$1' . home_url( '/videos/?filter=' ) . '$2', $output );
 
     echo $output;
     return false;

--- a/page-videos.php
+++ b/page-videos.php
@@ -21,50 +21,38 @@ get_header(); ?>
                 'paged'               => $current_page,
             );
 
-            switch ( $filter ) {
-                case 'latest':
-                    $query_args['orderby'] = 'date';
-                    $query_args['order']   = 'DESC';
-                    break;
-
-                case 'random':
-                    $query_args['orderby'] = 'rand';
-                    break;
-
-                case 'longest':
-                    $query_args['meta_key']   = 'duration';
-                    $query_args['orderby']    = 'meta_value_num';
-                    $query_args['order']      = 'DESC';
-                    $query_args['meta_type']  = 'NUMERIC';
-                    $query_args['meta_query'] = array(
-                        array(
-                            'key'     => 'duration',
-                            'compare' => 'EXISTS',
-                        ),
-                    );
-                    break;
-
-                case 'popular':
-                    $query_args['meta_key']   = 'post_views_count';
-                    $query_args['orderby']    = 'meta_value_num';
-                    $query_args['order']      = 'DESC';
-                    $query_args['meta_type']  = 'NUMERIC';
-                    $query_args['meta_query'] = array(
-                        array(
-                            'key'     => 'post_views_count',
-                            'compare' => 'EXISTS',
-                        ),
-                    );
-                    break;
-
-                default:
-                    $filter = '';
-                    break;
+            if ( 'latest' === $filter ) {
+                $query_args['orderby'] = 'date';
+                $query_args['order']   = 'DESC';
+            } elseif ( 'random' === $filter ) {
+                $query_args['orderby'] = 'rand';
+            } elseif ( 'longest' === $filter ) {
+                $query_args['meta_key']   = 'duration';
+                $query_args['orderby']    = 'meta_value_num';
+                $query_args['order']      = 'DESC';
+                $query_args['meta_type']  = 'NUMERIC';
+                $query_args['meta_query'] = array(
+                    array(
+                        'key'     => 'duration',
+                        'compare' => 'EXISTS',
+                    ),
+                );
+            } elseif ( 'popular' === $filter ) {
+                $query_args['meta_key']   = 'post_views_count';
+                $query_args['orderby']    = 'meta_value_num';
+                $query_args['order']      = 'DESC';
+                $query_args['meta_type']  = 'NUMERIC';
+                $query_args['meta_query'] = array(
+                    array(
+                        'key'     => 'post_views_count',
+                        'compare' => 'EXISTS',
+                    ),
+                );
+            } elseif ( is_numeric( $filter ) ) {
+                $query_args['cat'] = absint( $filter );
             }
 
-            if ( $filter ) {
-                $filter_query = new WP_Query( $query_args );
-            }
+            $filter_query = new WP_Query( $query_args );
         }
         ?>
 


### PR DESCRIPTION
## Summary
- tighten the widget video filter URL rewrite so it only targets bare ?filter links and avoids duplicating the /videos/ prefix
- expand the /videos/ template filter handling to cover category IDs and unknown slugs without dropping back to the default widgets

## Testing
- php -l functions.php
- php -l page-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68e11a7a6ae8832489ca6cd9220888f3