### PR TITLE
Use widget rendering for filtered videos page

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -8,51 +8,53 @@ get_header(); ?>
     <main id="main" class="site-main with-sidebar-right" role="main">
 
         <?php
-        $filter       = isset( $_GET['filter'] ) ? sanitize_text_field( wp_unslash( $_GET['filter'] ) ) : '';
-        $filter_query = null;
+        $filter   = isset( $_GET['filter'] ) ? sanitize_text_field( wp_unslash( $_GET['filter'] ) ) : '';
+        $instance = array();
 
         if ( $filter ) {
-            $current_page = max( 1, (int) get_query_var( 'paged' ), (int) get_query_var( 'page' ) );
-            $query_args = array(
-                'post_type'           => 'video',
-                'post_status'         => 'publish',
-                'posts_per_page'      => 12,
-                'ignore_sticky_posts' => true,
-                'paged'               => $current_page,
-            );
-
             if ( 'latest' === $filter ) {
-                $query_args['orderby'] = 'date';
-                $query_args['order']   = 'DESC';
+                $instance = array(
+                    'title'          => __( 'Latest videos', 'retrotube-child' ),
+                    'video_type'     => 'latest',
+                    'video_number'   => 12,
+                    'video_category' => 0,
+                );
             } elseif ( 'random' === $filter ) {
-                $query_args['orderby'] = 'rand';
+                $instance = array(
+                    'title'          => __( 'Random videos', 'retrotube-child' ),
+                    'video_type'     => 'random',
+                    'video_number'   => 12,
+                    'video_category' => 0,
+                );
             } elseif ( 'longest' === $filter ) {
-                $query_args['meta_key']   = 'duration';
-                $query_args['orderby']    = 'meta_value_num';
-                $query_args['order']      = 'DESC';
-                $query_args['meta_type']  = 'NUMERIC';
-                $query_args['meta_query'] = array(
-                    array(
-                        'key'     => 'duration',
-                        'compare' => 'EXISTS',
-                    ),
+                $instance = array(
+                    'title'          => __( 'Longest videos', 'retrotube-child' ),
+                    'video_type'     => 'longest',
+                    'video_number'   => 12,
+                    'video_category' => 0,
                 );
             } elseif ( 'popular' === $filter ) {
-                $query_args['meta_key']   = 'post_views_count';
-                $query_args['orderby']    = 'meta_value_num';
-                $query_args['order']      = 'DESC';
-                $query_args['meta_type']  = 'NUMERIC';
-                $query_args['meta_query'] = array(
-                    array(
-                        'key'     => 'post_views_count',
-                        'compare' => 'EXISTS',
-                    ),
+                $instance = array(
+                    'title'          => __( 'Most popular videos', 'retrotube-child' ),
+                    'video_type'     => 'popular',
+                    'video_number'   => 12,
+                    'video_category' => 0,
                 );
             } elseif ( is_numeric( $filter ) ) {
-                $query_args['cat'] = absint( $filter );
-            }
+                $category_id = absint( $filter );
+                $term        = get_term( $category_id, 'category' );
 
-            $filter_query = new WP_Query( $query_args );
+                if ( $term && ! is_wp_error( $term ) ) {
+                    /* translators: %s: video category name. */
+                    $title     = sprintf( __( '%s videos', 'retrotube-child' ), $term->name );
+                    $instance  = array(
+                        'title'          => $title,
+                        'video_type'     => 'category',
+                        'video_number'   => 12,
+                        'video_category' => $category_id,
+                    );
+                }
+            }
         }
         ?>
 
@@ -60,34 +62,24 @@ get_header(); ?>
             <h1 class="entry-title"><i class="fa fa-video-camera"></i> Videos</h1>
         </header>
 
-        <?php if ( $filter && $filter_query instanceof WP_Query ) : ?>
+        <?php if ( $filter ) : ?>
 
-            <?php if ( $filter_query->have_posts() ) : ?>
-                <section class="videos-filter-results">
-                    <?php
-                    while ( $filter_query->have_posts() ) :
-                        $filter_query->the_post();
-                        get_template_part( 'template-parts/loop', 'video' );
-                    endwhile;
-                    ?>
-                </section>
-
+            <?php if ( ! empty( $instance ) ) : ?>
                 <?php
-                the_posts_pagination(
+                the_widget(
+                    'wpst_WP_Widget_Videos_Block',
+                    $instance,
                     array(
-                        'total'   => (int) $filter_query->max_num_pages,
-                        'current' => isset( $current_page ) ? $current_page : 1,
-                        'add_args' => array(
-                            'filter' => $filter,
-                        ),
+                        'before_widget' => '<section class="widget widget_videos_block">',
+                        'after_widget'  => '</section>',
+                        'before_title'  => '<h2 class="widget-title">',
+                        'after_title'   => '</h2>',
                     )
                 );
                 ?>
             <?php else : ?>
                 <p><?php esc_html_e( 'No videos found for this filter.', 'retrotube-child' ); ?></p>
             <?php endif; ?>
-
-            <?php wp_reset_postdata(); ?>
 
         <?php elseif ( is_page( 'videos' ) ) : ?>
 


### PR DESCRIPTION
## Summary
- replace the custom filtered videos query with the existing `wpst_WP_Widget_Videos_Block`
- map each supported filter to widget configuration, including category handling and fallback messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1228c20a48324820815ace247dd39