### PR TITLE
Fix longest videos filter mapping

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -29,7 +29,7 @@ get_header(); ?>
             } elseif ( 'longest' === $filter ) {
                 $instance = array(
                     'title'          => __( 'Longest videos', 'retrotube-child' ),
-                    'video_type'     => 'longest',
+                    'video_type'     => 'duration',
                     'video_number'   => 12,
                     'video_category' => 0,
                 );


### PR DESCRIPTION
## Summary
- map the `longest` filter to the widget's duration type so the longest videos render correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e126e6731483248d0dfb62924f8ed5