### PR TITLE
Guard videos page query from parent filter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,17 @@
  * IMPORTANT: Single PHP block. Do not add another <?php inside this file.
  */
 
+/**
+ * Guard Videos page from parent pre_get_posts modifications.
+ */
+function tmw_videos_page_guard( $query ) {
+  if ( ! is_admin() && $query->is_main_query() && is_page( 'videos' ) ) {
+    // Prevent parent from hijacking the main query
+    remove_action( 'pre_get_posts', 'wpst_pre_get_posts', 10 );
+  }
+}
+add_action( 'pre_get_posts', 'tmw_videos_page_guard', 1 );
+
 /* ======================================================================
  * ONE-TIME MIGRATIONS
  * ====================================================================== */


### PR DESCRIPTION
## Summary
- add a pre_get_posts guard in the child theme so the Videos page main query is left untouched by the parent filter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12f41620083248efa8814a74e1281