### PR TITLE
Align longest videos widget slug

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -120,7 +120,7 @@ get_header(); ?>
                 'wpst_WP_Widget_Videos_Block',
                 array(
                     'title'          => 'Longest videos',
-                    'video_type'     => 'longest',
+                    'video_type'     => 'duration',
                     'video_number'   => 12,
                     'video_category' => 0,
                 ),


### PR DESCRIPTION
## Summary
- ensure the "Longest videos" widget consistently uses the duration slug

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e138303ba083248a7173602083447d