### PR TITLE
Restore longest videos widget slug

### DIFF
--- a/page-videos.php
+++ b/page-videos.php
@@ -29,7 +29,7 @@ get_header(); ?>
             } elseif ( 'longest' === $filter ) {
                 $instance = array(
                     'title'          => __( 'Longest videos', 'retrotube-child' ),
-                    'video_type'     => 'duration',
+                    'video_type'     => 'longest',
                     'video_number'   => 12,
                     'video_category' => 0,
                 );
@@ -120,7 +120,7 @@ get_header(); ?>
                 'wpst_WP_Widget_Videos_Block',
                 array(
                     'title'          => 'Longest videos',
-                    'video_type'     => 'duration',
+                    'video_type'     => 'longest',
                     'video_number'   => 12,
                     'video_category' => 0,
                 ),


### PR DESCRIPTION
## Summary
- revert the videos page widget configuration to pass the `longest` slug expected by wpst_WP_Widget_Videos_Block
- ensure the longest videos widget renders for both the default videos page and the ?filter=longest view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13c4464188324984cc8b2f3f0e788