### PR TITLE
Align model profile template with video layout scaffolding

### DIFF
--- a/single-model.php
+++ b/single-model.php
@@ -1,107 +1,247 @@
 <?php
 /**
- * Template for single model pages
- * Based on page-videos.php layout
+ * Template for single model pages that mirrors the video layout.
  */
 
-get_header(); ?>
+get_header();
+?>
+<div id="content" class="site-content row">
+    <div id="primary" class="content-area with-sidebar-right single-model">
+        <main id="main" class="site-main with-sidebar-right" role="main">
+            <?php if (have_posts()) : ?>
+                <?php while (have_posts()) : the_post(); ?>
+                    <?php error_log('[ModelPage] single-model.php loaded for ' . get_the_title()); ?>
+                    <?php
+                    $model_name   = get_the_title();
+                    $portrait_html = '';
+                    $portrait_url  = '';
 
-<div id="primary" class="content-area with-sidebar-right">
-    <main id="main" class="site-main with-sidebar-right" role="main">
+                    if (function_exists('get_field')) {
+                        $portrait_field = get_field('model_portrait');
 
-        <?php while ( have_posts() ) : the_post(); ?>
+                        if (is_array($portrait_field)) {
+                            if (!empty($portrait_field['ID'])) {
+                                $portrait_html = wp_get_attachment_image((int) $portrait_field['ID'], 'large', false, [
+                                    'class' => 'model-portrait-image',
+                                    'alt'   => $model_name,
+                                ]);
+                            } elseif (!empty($portrait_field['url'])) {
+                                $portrait_url = $portrait_field['url'];
+                            }
+                        } elseif (is_numeric($portrait_field)) {
+                            $portrait_html = wp_get_attachment_image((int) $portrait_field, 'large', false, [
+                                'class' => 'model-portrait-image',
+                                'alt'   => $model_name,
+                            ]);
+                        } elseif (is_string($portrait_field) && $portrait_field !== '') {
+                            $portrait_url = $portrait_field;
+                        }
+                    }
 
-            <div class="entry-content">
-                <?php
-                $portrait = function_exists('get_field') ? get_field('model_portrait') : '';
-                if (is_array($portrait) && !empty($portrait['url'])) {
-                    $portrait_url = $portrait['url'];
-                } else {
-                    $portrait_url = $portrait ? $portrait : get_the_post_thumbnail_url(get_the_ID(), 'large');
-                }
-                if ($portrait_url):
-                ?>
-                <div class="video-player box-shadow">
-                    <img src="<?php echo esc_url($portrait_url); ?>" alt="<?php echo esc_attr(get_the_title()); ?>">
-                </div>
-                <?php endif; ?>
+                    if (!$portrait_html && !$portrait_url && has_post_thumbnail()) {
+                        $portrait_html = get_the_post_thumbnail(get_the_ID(), 'large', [
+                            'class' => 'model-portrait-image',
+                            'alt'   => $model_name,
+                        ]);
+                    }
 
-                <div class="title-block box-shadow">
-                    <div class="video-meta-inline">
-                        <h1 class="entry-title"><i class="fa fa-user"></i> <?php the_title(); ?></h1>
-                    </div>
-                </div>
+                    if (!$portrait_html && $portrait_url) {
+                        $portrait_html = sprintf(
+                            '<img src="%s" alt="%s" class="model-portrait-image" />',
+                            esc_url($portrait_url),
+                            esc_attr($model_name)
+                        );
+                    }
 
-                <div id="video-tabs" class="tabs">
-                    <div class="tab-content">
-                        <div id="video-about" class="tab-pane">
-                            <div class="video-description">
-                                <div class="desc">
-                                    <?php the_content(); ?>
+                    $social_fields = [
+                        'instagram_url' => ['label' => 'Instagram', 'icon' => 'fa-instagram'],
+                        'twitter_url'   => ['label' => 'Twitter/X', 'icon' => 'fa-twitter'],
+                        'tiktok_url'    => ['label' => 'TikTok', 'icon' => 'fa-music'],
+                        'onlyfans_url'  => ['label' => 'OnlyFans', 'icon' => 'fa-star'],
+                        'fancentro_url' => ['label' => 'FanCentro', 'icon' => 'fa-plus'],
+                        'mymfans_url'   => ['label' => 'MyM.fans', 'icon' => 'fa-heart'],
+                    ];
 
-                                    <?php
-                                    if ( function_exists('get_field') ) :
-                                        $links = [
-                                            'instagram_url' => 'fa-instagram',
-                                            'twitter_url'   => 'fa-twitter',
-                                            'tiktok_url'    => 'fa-music',
-                                            'onlyfans_url'  => 'fa-star',
-                                            'fancentro_url' => 'fa-plus',
-                                            'mymfans_url'   => 'fa-heart'
-                                        ];
-                                        $has_links = false;
-                                        ob_start();
-                                        echo '<div class="model-social-links">';
-                                        foreach ( $links as $k => $icon ) {
-                                            $url = get_field($k);
-                                            if ( $url ) {
-                                                $has_links = true;
-                                                echo '<a href="' . esc_url($url) . '" target="_blank" rel="nofollow noopener"><i class="fa ' . esc_attr($icon) . '"></i></a> ';
-                                            }
-                                        }
-                                        echo '</div>';
-                                        $html = ob_get_clean();
-                                        if ( $has_links ) echo $html;
-                                    endif;
-                                    ?>
+                    $social_links = [];
+
+                    if (function_exists('get_field')) {
+                        foreach ($social_fields as $field_key => $meta) {
+                            $field_value = get_field($field_key);
+
+                            if (is_array($field_value) && isset($field_value['url'])) {
+                                $field_value = $field_value['url'];
+                            }
+
+                            if (is_string($field_value)) {
+                                $field_value = trim($field_value);
+                            }
+
+                            if (!empty($field_value)) {
+                                $social_links[] = [
+                                    'url'   => (string) $field_value,
+                                    'label' => $meta['label'],
+                                    'icon'  => $meta['icon'],
+                                ];
+                            }
+                        }
+                    }
+                    ?>
+
+                    <article id="post-<?php the_ID(); ?>" <?php post_class('model-profile'); ?>>
+                        <header class="entry-header">
+                            <?php if ($portrait_html) : ?>
+                                <div class="video-player box-shadow">
+                                    <?php echo $portrait_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                </div>
+                            <?php endif; ?>
+
+                            <div class="title-block box-shadow">
+                                <?php the_title('<h1 class="entry-title" itemprop="name">', '</h1>'); ?>
+                                <div id="video-tabs" class="tabs">
+                                    <button class="tab-link active about" data-tab-id="video-about">
+                                        <i class="fa fa-info-circle"></i> <?php esc_html_e('About', 'wpst'); ?>
+                                    </button>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                </div>
-            </div><!-- .entry-content -->
 
-            <?php
-            $model_name = get_the_title();
-            $model_videos = new WP_Query([
-                'post_type' => 'video',
-                'posts_per_page' => 6,
-                's' => $model_name,
-                'no_found_rows' => true,
-                'ignore_sticky_posts' => true,
-            ]);
+                            <div class="video-meta-inline">
+                                <span class="video-meta-item video-meta-author">
+                                    <i class="fa fa-user"></i>
+                                    <?php
+                                    $author_markup = sprintf(
+                                        '<a href="%s">%s</a>',
+                                        esc_url(get_author_posts_url(get_the_author_meta('ID'))),
+                                        esc_html(get_the_author())
+                                    );
+                                    echo wp_kses_post(
+                                        sprintf(
+                                            /* translators: %s: model author name */
+                                            __('Added by %s', 'wpst'),
+                                            $author_markup
+                                        )
+                                    );
+                                    ?>
+                                </span>
+                                <span class="video-meta-item video-meta-date">
+                                    <i class="fa fa-calendar"></i>
+                                    <?php
+                                    printf(
+                                        /* translators: %s: published date */
+                                        esc_html__('Published %s', 'wpst'),
+                                        esc_html(get_the_date())
+                                    );
+                                    ?>
+                                </span>
+                                <?php
+                                $model_terms = get_the_terms(get_the_ID(), 'model-category');
+                                if (!empty($model_terms) && !is_wp_error($model_terms)) :
+                                    $term_links = [];
+                                    foreach ($model_terms as $term) {
+                                        $term_link = get_term_link($term);
+                                        if (!is_wp_error($term_link)) {
+                                            $term_links[] = sprintf('<a href="%s">%s</a>', esc_url($term_link), esc_html($term->name));
+                                        }
+                                    }
+                                    if ($term_links) :
+                                        ?>
+                                        <span class="video-meta-item video-meta-model">
+                                            <i class="fa fa-tags"></i>
+                                            <?php
+                                            echo wp_kses_post(
+                                                sprintf(
+                                                    /* translators: %s: comma separated list of model categories */
+                                                    __('Categories: %s', 'wpst'),
+                                                    implode(', ', $term_links)
+                                                )
+                                            );
+                                            ?>
+                                        </span>
+                                        <?php
+                                    endif;
+                                endif;
+                                ?>
+                            </div>
 
-            if ( $model_videos->have_posts() ) :
-            ?>
-            <section class="related-videos box-shadow">
-                <h3 class="widget-title"><i class="fa fa-video-camera"></i> Model Videos</h3>
-                <div class="video-loop">
-                    <?php while ( $model_videos->have_posts() ) : $model_videos->the_post(); ?>
-                        <?php get_template_part('template-parts/loop', 'video'); ?>
-                    <?php endwhile; wp_reset_postdata(); ?>
-                </div>
-            </section>
+                            <div class="clear"></div>
+                        </header>
+
+                        <div class="entry-content">
+                            <div class="tab-content">
+                                <div id="video-about" class="width100">
+                                    <div class="video-description">
+                                        <div class="desc">
+                                            <?php the_content(); ?>
+                                        </div>
+                                    </div>
+
+                                    <?php if (!empty($social_links)) : ?>
+                                        <div class="model-social-links">
+                                            <ul class="social-icons">
+                                                <?php foreach ($social_links as $social_link) : ?>
+                                                    <li>
+                                                        <a href="<?php echo esc_url($social_link['url']); ?>" target="_blank" rel="nofollow noopener">
+                                                            <i class="fa <?php echo esc_attr($social_link['icon']); ?>"></i>
+                                                            <span class="screen-reader-text"><?php echo esc_html($social_link['label']); ?></span>
+                                                        </a>
+                                                    </li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+
+                                    <?php if (has_tag()) : ?>
+                                        <div class="video-tags"><?php the_tags('', ' ', ''); ?></div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div><!-- .entry-content -->
+
+                        <?php
+                        $model_videos = new WP_Query([
+                            'post_type'           => 'video',
+                            'posts_per_page'      => 6,
+                            's'                   => $model_name,
+                            'no_found_rows'       => true,
+                            'ignore_sticky_posts' => true,
+                        ]);
+
+                        if ($model_videos->have_posts()) :
+                            ?>
+                            <section class="related-videos box-shadow">
+                                <h3 class="widget-title">
+                                    <i class="fa fa-video-camera"></i>
+                                    <?php
+                                    printf(
+                                        /* translators: %s: model name */
+                                        esc_html__('Related videos by %s', 'wpst'),
+                                        esc_html($model_name)
+                                    );
+                                    ?>
+                                </h3>
+                                <div class="video-loop">
+                                    <?php
+                                    while ($model_videos->have_posts()) :
+                                        $model_videos->the_post();
+                                        get_template_part('template-parts/loop', 'video');
+                                    endwhile;
+                                    ?>
+                                </div>
+                            </section>
+                            <?php
+                        endif;
+
+                        wp_reset_postdata();
+                        ?>
+
+                        <?php comments_template(); ?>
+                    </article>
+                <?php endwhile; ?>
             <?php endif; ?>
-
-            <div class="video-tags"><?php the_tags('', ' ', ''); ?></div>
-            <?php comments_template(); ?>
-
-        <?php endwhile; ?>
-
-    </main><!-- #main -->
-</div><!-- #primary -->
-
-<?php get_sidebar(); ?>
-<?php get_footer(); ?>
-
-<?php error_log('[ModelPage] single-model.php loaded for ' . get_the_title()); ?>
+        </main>
+    </div>
+    <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
+        <?php get_sidebar(); ?>
+    </aside>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- rebuild the single model template to mirror the video layout structure with the hero portrait, title block, tabs, and metadata row
- render model content, social links, tags, related videos, and comments inside the shared entry-content container
- keep the sidebar in place while using a scoped related videos query for the model profile

## Testing
- php -l single-model.php

------
https://chatgpt.com/codex/tasks/task_e_68e25d894b9883248afc83b8b72737c3