### PR TITLE
Rebuild single model template with ACF layout

### DIFF
--- a/single-model.php
+++ b/single-model.php
@@ -1,186 +1,129 @@
 <?php
 /**
- * Single Model template cloned from the video layout.
- * Remove this file if layout breaks; WordPress will fall back to the parent template.
+ * Template for displaying single Model posts
+ * Fully matches RetroTube video layout but uses ACF model fields
  */
 
 get_header();
+
+if (have_posts()) :
+while (have_posts()) : the_post();
+
+  $model_id   = get_the_ID();
+  $model_name = get_the_title();
+
+  // ACF fields
+  $banner_image      = get_field('banner_image', $model_id);
+  $model_link        = get_field('model_link', $model_id);
+  $flipbox_shortcode = get_field('flipbox_shortcode', $model_id);
+  $bio               = get_field('model', $model_id);
+
+  // Debug logging
+  error_log('[ModelLayout] single-model.php loaded for ' . $model_name);
+  if (!$banner_image)      error_log('[ModelLayout] No banner_image for ' . $model_name);
+  if (!$model_link)        error_log('[ModelLayout] No model_link for ' . $model_name);
+  if (!$flipbox_shortcode) error_log('[ModelLayout] No flipbox_shortcode for ' . $model_name);
+  if (!$bio)               error_log('[ModelLayout] No model bio (ACF field "model") for ' . $model_name);
 ?>
-<div id="content" class="site-content row">
-    <div id="primary" class="content-area with-sidebar-right single-model">
-        <main id="main" class="site-main with-sidebar-right" role="main">
-            <?php if (have_posts()) : ?>
-                <?php while (have_posts()) : the_post(); ?>
-                    <?php
-                    $model_id   = get_the_ID();
-                    $model_name = get_the_title();
-                    $model_slug = get_post_field('post_name', $model_id);
+<div id="primary" class="content-area">
+  <main id="main" class="site-main" role="main">
 
-                    error_log('[ModelPage] Bulletproof layout loaded for ' . $model_name);
-
-                    $portrait_html  = '';
-                    $portrait_field = function_exists('get_field') ? get_field('model_portrait') : null;
-
-                    if (is_array($portrait_field) && !empty($portrait_field['ID'])) {
-                        $portrait_html = wp_get_attachment_image(
-                            (int) $portrait_field['ID'],
-                            'large',
-                            false,
-                            [
-                                'class' => 'model-portrait',
-                                'alt'   => $model_name,
-                            ]
-                        );
-                    } elseif (!empty($portrait_field) && is_numeric($portrait_field)) {
-                        $portrait_html = wp_get_attachment_image(
-                            (int) $portrait_field,
-                            'large',
-                            false,
-                            [
-                                'class' => 'model-portrait',
-                                'alt'   => $model_name,
-                            ]
-                        );
-                    } elseif (is_array($portrait_field) && !empty($portrait_field['url'])) {
-                        $portrait_html = sprintf(
-                            '<img src="%s" alt="%s" class="model-portrait" />',
-                            esc_url($portrait_field['url']),
-                            esc_attr($model_name)
-                        );
-                    } elseif (is_string($portrait_field) && $portrait_field !== '') {
-                        $portrait_html = sprintf(
-                            '<img src="%s" alt="%s" class="model-portrait" />',
-                            esc_url($portrait_field),
-                            esc_attr($model_name)
-                        );
-                    }
-
-                    if (!$portrait_html && has_post_thumbnail()) {
-                        $portrait_html = get_the_post_thumbnail(
-                            $model_id,
-                            'large',
-                            [
-                                'class' => 'model-portrait',
-                                'alt'   => $model_name,
-                            ]
-                        );
-                    }
-
-                    if (!$portrait_html) {
-                        $placeholder_file = get_stylesheet_directory() . '/images/placeholder-model.jpg';
-                        $placeholder_url  = get_stylesheet_directory_uri() . '/images/placeholder-model.jpg';
-
-                        if (!file_exists($placeholder_file)) {
-                            $fallback_path = get_stylesheet_directory_uri() . '/assets/images/placeholder-model.jpg';
-                            $placeholder_url = $fallback_path;
-                        }
-
-                        $portrait_html = sprintf(
-                            '<img src="%s" alt="%s" class="model-portrait" />',
-                            esc_url($placeholder_url),
-                            esc_attr($model_name)
-                        );
-                    }
-
-                    // Ensure portrait markup includes schema itemprop.
-                    $portrait_markup = str_replace('<img ', '<img itemprop="image" ', $portrait_html);
-
-                    $views_meta_key = 'views';
-                    $views_count    = get_post_meta($model_id, $views_meta_key, true);
-                    $views_display  = $views_count !== '' ? absint($views_count) : 1280;
-                    ?>
-
-                    <article id="post-<?php the_ID(); ?>" <?php post_class('video-page'); ?> itemscope itemtype="https://schema.org/Person">
-                        <header class="entry-header">
-                            <div class="video-player box-shadow">
-                                <?php echo $portrait_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                            </div>
-
-                            <div class="title-block box-shadow">
-                                <?php the_title('<h1 class="entry-title" itemprop="name">', '</h1>'); ?>
-                                <div id="rating" class="model-rating-disabled">
-                                    <span id="video-rate"><i class="fa fa-user"></i> <?php esc_html_e('Model profile', 'wpst'); ?></span>
-                                </div>
-                                <div id="video-tabs" class="tabs">
-                                    <button class="tab-link active about" data-tab-id="video-about">
-                                        <i class="fa fa-info-circle"></i> <?php esc_html_e('About', 'wpst'); ?>
-                                    </button>
-                                    <button class="tab-link comments" data-tab-id="video-comments">
-                                        <i class="fa fa-comments"></i> <?php esc_html_e('Comments', 'wpst'); ?>
-                                    </button>
-                                </div>
-                            </div>
-
-                            <div class="video-meta-inline">
-                                <span class="video-meta-item video-meta-author"><i class="fa fa-user"></i> <?php esc_html_e('Added by', 'wpst'); ?> <?php the_author_posts_link(); ?></span>
-                                <span class="video-meta-item video-meta-date"><i class="fa fa-calendar"></i> <?php echo esc_html(get_the_date()); ?></span>
-                                <span class="video-meta-item video-meta-category"><i class="fa fa-folder-open"></i> <a href="<?php echo esc_url(home_url('/models/')); ?>"><?php esc_html_e('Models', 'wpst'); ?></a></span>
-                                <span class="video-meta-item video-meta-views"><i class="fa fa-eye"></i> <?php echo esc_html(number_format_i18n($views_display)); ?> <?php esc_html_e('views', 'wpst'); ?></span>
-                            </div>
-
-                            <div class="clear"></div>
-                        </header>
-
-                        <div class="entry-content">
-                            <div id="video-about" class="tab-content active" itemprop="description">
-                                <?php the_content(); ?>
-
-                                <?php if (has_tag()) : ?>
-                                    <div class="video-tags"><?php the_tags('<span class="video-meta-item"><i class="fa fa-tags"></i> ', ', ', '</span>'); ?></div>
-                                <?php endif; ?>
-                            </div>
-
-                            <div id="video-comments" class="tab-content">
-                                <?php comments_template(); ?>
-                            </div>
-                        </div>
-
-                        <?php
-                        if (!empty($model_slug)) {
-                            $related_videos = new WP_Query([
-                                'post_type'           => 'video',
-                                'posts_per_page'      => 6,
-                                'post_status'         => 'publish',
-                                'ignore_sticky_posts' => true,
-                                'tag'                 => $model_slug,
-                            ]);
-
-                            if ($related_videos->have_posts()) :
-                                ?>
-                                <section class="related-videos box-shadow">
-                                    <h3 class="widget-title">
-                                        <i class="fa fa-video-camera"></i>
-                                        <?php
-                                        printf(
-                                            /* translators: %s: model name. */
-                                            esc_html__('Related videos featuring %s', 'wpst'),
-                                            esc_html($model_name)
-                                        );
-                                        ?>
-                                    </h3>
-                                    <div class="video-loop">
-                                        <?php
-                                        while ($related_videos->have_posts()) :
-                                            $related_videos->the_post();
-                                            get_template_part('template-parts/loop', 'video');
-                                        endwhile;
-                                        ?>
-                                    </div>
-                                </section>
-                                <?php
-                            endif;
-
-                            wp_reset_postdata();
-                        }
-                        ?>
-                    </article>
-                <?php endwhile; ?>
-            <?php endif; ?>
-        </main>
+    <!-- Title Block -->
+    <div class="title-block box-shadow">
+      <h1 class="entry-title"><?php echo esc_html($model_name); ?></h1>
     </div>
-    <aside id="sidebar" class="widget-area with-sidebar-right" role="complementary">
-        <?php get_sidebar(); ?>
-    </aside>
+
+    <!-- Banner -->
+    <?php if ($banner_image): ?>
+      <div class="video-player box-shadow">
+        <img src="<?php echo esc_url($banner_image['url']); ?>" alt="<?php echo esc_attr($model_name); ?>" class="aligncenter"/>
+      </div>
+    <?php endif; ?>
+
+    <!-- Meta Strip -->
+    <div class="video-meta-inline">
+      <ul class="meta-list">
+        <?php if ($model_link): ?>
+          <li><a href="<?php echo esc_url($model_link); ?>" class="btn btn-primary" target="_blank">
+            <i class="fa fa-video-camera"></i> <?php esc_html_e('Watch Live', 'retrotube'); ?>
+          </a></li>
+        <?php endif; ?>
+      </ul>
+    </div>
+
+    <!-- Tabs -->
+    <div id="video-tabs" class="tabs">
+      <ul class="tab-buttons">
+        <li class="active"><a href="#tab-description"><?php esc_html_e('About', 'retrotube'); ?></a></li>
+        <li><a href="#tab-videos"><?php esc_html_e('Videos', 'retrotube'); ?></a></li>
+        <li><a href="#tab-comments"><?php esc_html_e('Comments', 'retrotube'); ?></a></li>
+      </ul>
+
+      <div class="tab-content">
+
+        <!-- Tab: About -->
+        <div id="tab-description" class="tab active">
+          <div class="entry-content">
+            <?php
+              if ($bio) echo wpautop($bio);
+              else the_content();
+
+              if ($flipbox_shortcode) {
+                echo '<div class="model-flipbox">';
+                echo do_shortcode($flipbox_shortcode);
+                echo '</div>';
+              }
+
+              if (has_tag()) :
+                echo '<div class="post-tags">';
+                the_tags('<strong>Tags:</strong> ', ', ');
+                echo '</div>';
+              endif;
+            ?>
+          </div>
+        </div>
+
+        <!-- Tab: Videos -->
+        <div id="tab-videos" class="tab">
+          <?php
+          $related = new WP_Query([
+            'post_type' => 'video',
+            'posts_per_page' => 6,
+            'meta_query' => [
+              [
+                'key'     => 'related_model',
+                'value'   => $model_name,
+                'compare' => 'LIKE',
+              ]
+            ]
+          ]);
+          if ($related->have_posts()) :
+            echo '<div class="related-videos-grid">';
+            while ($related->have_posts()) : $related->the_post();
+              get_template_part('template-parts/loop', 'video');
+            endwhile;
+            echo '</div>';
+            wp_reset_postdata();
+          else :
+            echo '<p>' . esc_html__('No videos found for this model.', 'retrotube') . '</p>';
+          endif;
+          ?>
+        </div>
+
+        <!-- Tab: Comments -->
+        <div id="tab-comments" class="tab">
+          <?php comments_template(); ?>
+        </div>
+
+      </div><!-- .tab-content -->
+    </div><!-- #video-tabs -->
+
+  </main>
 </div>
+
 <?php
+endwhile;
+endif;
+
 get_footer();
+?>


### PR DESCRIPTION
## Summary
- replace the single model template with a RetroTube-style layout that pulls banner, link, flipbox, and bio data from ACF fields
- add debug logging for missing ACF fields to simplify diagnosing incomplete model data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e37d7eecb48324b262000d7610df38