### PR TITLE
Fix banner_image array/string TypeError and auto-flush rewrite rules for model permalinks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2715,3 +2715,8 @@ function rt_child_sync_model_profile( $model_post_id, $video_post_id ) {
 
     error_log('[ModelSync] Synced performer “' . $performer_name . '” (' . $model_post_id . ') with video ' . $video_post_id);
 }
+
+add_action('after_switch_theme', function () {
+    flush_rewrite_rules();
+    error_log('[ModelFix] Flushed rewrite rules after theme activation.');
+});

--- a/single-model.php
+++ b/single-model.php
@@ -35,8 +35,12 @@ while (have_posts()) : the_post();
 
     <!-- Banner -->
     <?php if ($banner_image): ?>
+      <?php
+        // Handle both array or string formats
+        $banner_url = is_array($banner_image) ? $banner_image['url'] : $banner_image;
+      ?>
       <div class="video-player box-shadow">
-        <img src="<?php echo esc_url($banner_image['url']); ?>" alt="<?php echo esc_attr($model_name); ?>" class="aligncenter"/>
+        <img src="<?php echo esc_url($banner_url); ?>" alt="<?php echo esc_attr($model_name); ?>" class="aligncenter"/>
       </div>
     <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- handle ACF banner_image returning either an array or string so the model banner always renders
- add an after_switch_theme hook that flushes rewrite rules once after activation to keep model permalinks valid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e37f7ce75c83248c686ce60dfe0034