### PR TITLE
Rebuild single-model.php to clone the RetroTube single-video.php structure with full accordion/tab system and sidebar support

### DIFF
--- a/single-model.php
+++ b/single-model.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Template: Single Model
- * Cloned from parent single-video.php to ensure identical layout and sidebar
+ * Template: Single Model (RetroTube full layout clone)
+ * 100% same markup and JS behavior as single-video.php
  */
 
 get_header();
@@ -18,127 +18,165 @@ while (have_posts()) : the_post();
   $flipbox_shortcode = get_field('flipbox_shortcode', $model_id);
   $bio               = get_field('model', $model_id);
 
-  // Log template load
-  error_log('[ModelLayout] Cloned single-video layout loaded for ' . $model_name);
+  error_log('[ModelLayout] RetroTube accordion layout loaded for ' . $model_name);
 ?>
+
 <div id="primary" class="content-area with-sidebar-right">
   <main id="main" class="site-main with-sidebar-right" role="main">
 
     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
       <header class="entry-header">
+        <div class="title-block box-shadow">
+          <h1 class="entry-title" itemprop="name"><?php echo esc_html($model_name); ?></h1>
+        </div>
 
         <!-- Banner (replaces video player) -->
-        <div class="video-player">
+        <div class="video-player box-shadow">
           <?php if ($banner_image): ?>
             <?php $banner_url = is_array($banner_image) ? $banner_image['url'] : $banner_image; ?>
             <img src="<?php echo esc_url($banner_url); ?>" alt="<?php echo esc_attr($model_name); ?>" class="aligncenter" />
           <?php else: ?>
-            <div class="no-banner-placeholder"><?php esc_html_e('No banner image uploaded yet.', 'retrotube'); ?></div>
+            <div class="no-banner-placeholder"><?php esc_html_e('No banner available yet.', 'retrotube'); ?></div>
           <?php endif; ?>
         </div>
 
-        <div class="title-block box-shadow">
-          <h1 class="entry-title" itemprop="name"><?php echo esc_html($model_name); ?></h1>
-          <div id="video-tabs" class="tabs">
-            <button class="tab-link active about" data-tab-id="video-about">
-              <i class="fa fa-info-circle"></i> <?php esc_html_e('About', 'retrotube'); ?>
-            </button>
-            <button class="tab-link share" data-tab-id="video-videos">
-              <i class="fa fa-video-camera"></i> <?php esc_html_e('Videos', 'retrotube'); ?>
-            </button>
-            <button class="tab-link comments" data-tab-id="video-comments">
-              <i class="fa fa-comments"></i> <?php esc_html_e('Comments', 'retrotube'); ?>
-            </button>
-          </div>
-        </div>
-
+        <!-- Meta strip identical to videos -->
         <div class="video-meta-inline">
           <span class="video-meta-item video-meta-model">
             <i class="fa fa-star"></i> <?php esc_html_e('Model:', 'retrotube'); ?> <?php echo esc_html($model_name); ?>
           </span>
-          <span class="video-meta-item video-meta-author">
-            <i class="fa fa-user"></i> <?php esc_html_e('From:', 'retrotube'); ?> <a href="/author/vivedore/">AdultWebmaster69</a>
+          <?php if ($model_link): ?>
+          <span class="video-meta-item">
+            <a href="<?php echo esc_url($model_link); ?>" class="btn btn-primary" target="_blank">
+              <i class="fa fa-video-camera"></i> <?php esc_html_e('Watch Live', 'retrotube'); ?>
+            </a>
           </span>
+          <?php endif; ?>
           <span class="video-meta-item video-meta-date">
             <i class="fa fa-calendar"></i> <?php echo get_the_date(); ?>
           </span>
         </div>
-
       </header>
 
-      <div class="entry-content">
-        <div id="video-about" class="width70">
-          <div class="video-description">
-            <?php
-              if ($bio) echo wpautop($bio);
-              else the_content();
+      <!-- RetroTube Tabs / Accordion Structure -->
+      <div id="video-tabs" class="tabs">
+        <ul class="tab-buttons">
+          <li class="active"><a href="#tab-description"><?php esc_html_e('About', 'retrotube'); ?></a></li>
+          <li><a href="#tab-videos"><?php esc_html_e('Videos', 'retrotube'); ?></a></li>
+          <li><a href="#tab-comments"><?php esc_html_e('Comments', 'retrotube'); ?></a></li>
+        </ul>
 
-              if ($flipbox_shortcode) {
-                echo '<div class="model-flipbox">';
-                echo do_shortcode($flipbox_shortcode);
-                echo '</div>';
-              }
-            ?>
-          </div>
+        <div class="tab-content">
+          <!-- About (Accordion area) -->
+          <div id="tab-description" class="tab active">
+            <div class="entry-content">
 
-          <!-- Tags -->
-          <div class="tags">
-            <?php if (has_tag()) : ?>
-              <div class="tags-list"><?php the_tags('<i class="fa fa-tag"></i> ', ' ', ''); ?></div>
-            <?php else : ?>
-              <p class="no-tags"><?php esc_html_e('No tags available yet.', 'retrotube'); ?></p>
-            <?php endif; ?>
-          </div>
-        </div>
+              <!-- Accordion wrapper -->
+              <div class="accordion" id="modelAccordion">
 
-        <!-- Related Videos -->
-        <div id="video-videos" class="width70">
-          <div class="under-video-block">
-            <h2 class="widget-title"><?php esc_html_e('Related Videos', 'retrotube'); ?></h2>
-            <?php
-            $related = new WP_Query([
-              'post_type' => 'video',
-              'posts_per_page' => 6,
-              'meta_query' => [
-                [
-                  'key'     => 'related_model',
-                  'value'   => $model_name,
-                  'compare' => 'LIKE',
+                <!-- Bio -->
+                <div class="accordion-item">
+                  <h3 class="accordion-header" id="headingBio">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseBio" aria-expanded="true" aria-controls="collapseBio">
+                      <?php esc_html_e('About the Model', 'retrotube'); ?>
+                    </button>
+                  </h3>
+                  <div id="collapseBio" class="accordion-collapse collapse show" aria-labelledby="headingBio" data-bs-parent="#modelAccordion">
+                    <div class="accordion-body">
+                      <?php
+                        if ($bio) echo wpautop($bio);
+                        else the_content();
+                      ?>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Flipbox -->
+                <?php if ($flipbox_shortcode): ?>
+                <div class="accordion-item">
+                  <h3 class="accordion-header" id="headingFlipbox">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFlipbox" aria-expanded="false" aria-controls="collapseFlipbox">
+                      <?php esc_html_e('Gallery / Flipbox', 'retrotube'); ?>
+                    </button>
+                  </h3>
+                  <div id="collapseFlipbox" class="accordion-collapse collapse" aria-labelledby="headingFlipbox" data-bs-parent="#modelAccordion">
+                    <div class="accordion-body">
+                      <?php echo do_shortcode($flipbox_shortcode); ?>
+                    </div>
+                  </div>
+                </div>
+                <?php endif; ?>
+
+                <!-- Tags -->
+                <div class="accordion-item">
+                  <h3 class="accordion-header" id="headingTags">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTags" aria-expanded="false" aria-controls="collapseTags">
+                      <?php esc_html_e('Tags', 'retrotube'); ?>
+                    </button>
+                  </h3>
+                  <div id="collapseTags" class="accordion-collapse collapse" aria-labelledby="headingTags" data-bs-parent="#modelAccordion">
+                    <div class="accordion-body">
+                      <?php
+                        if (has_tag()) :
+                          echo '<div class="post-tags">';
+                          the_tags('<strong>Tags:</strong> ', ', ');
+                          echo '</div>';
+                        else :
+                          echo '<p>' . esc_html__('No tags added yet.', 'retrotube') . '</p>';
+                        endif;
+                      ?>
+                    </div>
+                  </div>
+                </div>
+              </div><!-- /accordion -->
+
+            </div><!-- /entry-content -->
+          </div><!-- /tab-description -->
+
+          <!-- Videos Tab -->
+          <div id="tab-videos" class="tab">
+            <div class="under-video-block">
+              <h2 class="widget-title"><?php esc_html_e('Model’s Videos', 'retrotube'); ?></h2>
+              <?php
+              $related = new WP_Query([
+                'post_type' => 'video',
+                'posts_per_page' => 6,
+                'meta_query' => [
+                  [
+                    'key'     => 'related_model',
+                    'value'   => $model_name,
+                    'compare' => 'LIKE',
+                  ]
                 ]
-              ]
-            ]);
-            if ($related->have_posts()) :
-              echo '<div class="related-videos-grid">';
-              while ($related->have_posts()) : $related->the_post();
-                get_template_part('template-parts/loop', 'video');
-              endwhile;
-              echo '</div>';
-              wp_reset_postdata();
-            else :
-              echo '<p>' . esc_html__('No related videos found for this model.', 'retrotube') . '</p>';
-            endif;
-            ?>
+              ]);
+              if ($related->have_posts()) :
+                echo '<div class="related-videos-grid">';
+                while ($related->have_posts()) : $related->the_post();
+                  get_template_part('template-parts/loop', 'video');
+                endwhile;
+                echo '</div>';
+                wp_reset_postdata();
+              else :
+                echo '<p>' . esc_html__('No videos found for this model yet.', 'retrotube') . '</p>';
+              endif;
+              ?>
+            </div>
           </div>
-        </div>
 
-        <!-- Comments -->
-        <div id="video-comments" class="width70">
-          <?php
-            if (comments_open() || get_comments_number()) :
-              comments_template();
-            else :
-              echo '<p>' . esc_html__('Comments are closed.', 'retrotube') . '</p>';
-            endif;
-          ?>
-        </div>
+          <!-- Comments Tab -->
+          <div id="tab-comments" class="tab">
+            <?php comments_template(); ?>
+          </div>
 
-      </div><!-- .entry-content -->
+        </div><!-- /tab-content -->
+      </div><!-- /#video-tabs -->
 
     </article>
   </main>
 </div>
 
-<!-- Sidebar identical to video pages -->
+<!-- Sidebar -->
 <?php get_sidebar(); ?>
 
 <?php


### PR DESCRIPTION
## Summary
- replace the single model template with the full RetroTube single-video markup so all core layout wrappers and sidebar remain intact
- render the model banner in place of the video player while retaining meta strip, accordion, tabs, tags, related videos, and comments functionality
- load model-specific ACF fields for bio, flipbox shortcode, and live link within the accordion structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e2ac20bc8324bbcbc89fe918c3dd