### PR TITLE
Fix flipbox asset enqueue for shortcode contexts

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -27,11 +27,11 @@ if (!function_exists('tmw_child_style_version')) {
  * STYLES + LIGHTWEIGHT OPTIMIZATIONS
  * ====================================================================== */
 function tmw_child_has_flipbox_shortcode(): bool {
-  if (is_admin()) {
+  if (is_admin() || !is_singular()) {
     return false;
   }
 
-  global $post;
+  $post = get_queried_object();
 
   if (!($post instanceof WP_Post)) {
     return false;


### PR DESCRIPTION
## Summary
- guard shortcode detection during enqueue against missing queried objects

## Testing
- php -l inc/enqueue.php

------
https://chatgpt.com/codex/tasks/task_b_690c6d3b26ac832f94b2e2eed06bf55c