### PR TITLE
TMW Auth v4.12 — Hand off Login/Register/Reset to Theme My Login.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -40,11 +40,7 @@ define('TMW_CHILD_URL',  get_stylesheet_directory_uri());
 
 // Single include: all logic is now in /inc/bootstrap.php
 require_once TMW_CHILD_PATH . '/inc/bootstrap.php';
-
-// Theme My Login link bridge (debug-only loader).
-if (defined('TMW_DEBUG') && TMW_DEBUG && file_exists(__DIR__ . '/inc/tmw-tml-bridge.php')) {
-    require_once __DIR__ . '/inc/tmw-tml-bridge.php';
-}
+require_once __DIR__ . '/inc/tmw-tml-bridge.php';
 
 // Ensure legacy experiments don't affect the default reset email contents.
 remove_all_filters('retrieve_password_message');

--- a/inc/tmw-tml-bridge.php
+++ b/inc/tmw-tml-bridge.php
@@ -1,10 +1,6 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-if (!defined('TMW_DEBUG') || !TMW_DEBUG) {
-    return;
-}
-
 final class TMW_TML_Bridge {
     const TAG = '[TMW-TML]';
 


### PR DESCRIPTION
## Summary
- load the Theme My Login bridge unconditionally from the child theme bootstrap
- activate the TML header link rewiring bridge outside of debug-only mode so links point to TML pages

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690c85ea7854832fa71b706bffe304eb