### PR TITLE
TMW Auth v4.12 — Hand off Login/Register/Reset to Theme My Login.

### DIFF
--- a/js/tmw-tml-links.js
+++ b/js/tmw-tml-links.js
@@ -6,7 +6,7 @@
       a.setAttribute('data-tmw-tml', '1');
       a.removeAttribute('data-toggle');
       a.removeAttribute('data-target');
-      a.classList.remove('open-login','open-register');
+      a.classList.remove('open-login','open-register','open-lostpass','open-reset');
     } catch(e){}
   }
 
@@ -20,6 +20,8 @@
         setHref(a, '/login/');
       } else if (t === 'register' || t === 'sign up' || t === 'signup') {
         setHref(a, '/register/');
+      } else if (t.indexOf('reset') >= 0) {
+        setHref(a, '/resetpass/');
       } else if (t.indexOf('forgot') >= 0 || t.indexOf('lost') >= 0) {
         setHref(a, '/lostpassword/');
       }


### PR DESCRIPTION
## Summary
- expand the tmw-tml-links helper so header buttons also route reset-password text to `/resetpass/`
- strip any remaining popup trigger classes when retargeting the header links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690d1c4c17fc832fa4cbb681c9a93f57